### PR TITLE
[risk=no] Add dep check plugin

### DIFF
--- a/public-api/build.gradle
+++ b/public-api/build.gradle
@@ -79,6 +79,7 @@ buildscript {    // Configuration for building
     classpath 'com.google.cloud.tools:appengine-gradle-plugin:1.3.5'
     classpath 'gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:2.12.0'
     classpath 'io.swagger:swagger-codegen:2.2.3'
+    classpath 'org.owasp:dependency-check-gradle:3.1.0'
   }
 }
 
@@ -91,6 +92,7 @@ apply plugin: 'war'
 apply plugin: 'com.google.cloud.tools.appengine-standard'  // App Engine tasks
 apply plugin: 'org.springframework.boot'
 apply plugin: 'org.hidetake.swagger.generator'
+apply plugin: 'org.owasp.dependencycheck'
 
 sourceSets {
   generated {


### PR DESCRIPTION
This is required by the staging deployment CircleCI workflow:
https://circleci.com/gh/all-of-us/data-browser/176
