### PR TITLE
[risk=low] removing application type

### DIFF
--- a/public-api/src/main/resources/public-api.yaml
+++ b/public-api/src/main/resources/public-api.yaml
@@ -191,8 +191,6 @@ paths:
     post:
       tags:
         - dataBrowser
-      consumes:
-        - application/json
       description: Gets list of matched concepts
       operationId: "searchConcepts"
       parameters:


### PR DESCRIPTION
1. Application type addition on post request causes the api to spin forever. so, removing it.