### PR TITLE
[risk=no] prod cdr version update

### DIFF
--- a/public-api/config/cdr_versions_prod.json
+++ b/public-api/config/cdr_versions_prod.json
@@ -20,6 +20,6 @@
     "creationTime": "2018-11-13 15:09:27Z",
     "releaseNumber": 1,
     "numParticipants": 116460,
-    "publicDbName": "p_2019q1_2"
+    "publicDbName": "p_2019q1_3"
   }
 ]


### PR DESCRIPTION
1. Updating prod cdr version with age decile changes in the achilles results.