### PR TITLE
Revert "[DB-354][risk=low] Switch the prod UI to the prod API domain"

### DIFF
--- a/public-ui/src/environments/environment.prod.ts
+++ b/public-ui/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   displayTag: '',
-  publicApiUrl: 'https://public.api.researchallofus.org',
+  publicApiUrl: 'https://api-dot-aou-db-prod.appspot.com',
   workbenchUrl: 'https://workbench.researchallofus.org',
   researchAllOfUsUrl: 'https://researchallofus.org',
   clientId: '684273740878-d7i68in5d9hqr6n9mfvrdh53snekp79f.apps.googleusercontent.com',


### PR DESCRIPTION
Reverts all-of-us/data-browser#105

We're still waiting for the prod domains to update, so we need to revert this or prod will break.