### PR TITLE
[DB-370][risk=low] Improve domain search perf

### DIFF
--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
@@ -18,16 +18,28 @@ public interface DomainInfoDao extends CrudRepository<DomainInfo, Long> {
    * @param query the exact query that the user entered
    * @param conceptId the converted ID value for the query, or null
    */
-  @Query(value="select new org.pmiops.workbench.cdr.model.DomainInfo(\n" +
-      "d.domain, d.domainId, d.name, d.description,\n" +
-      "d.conceptId, 0L, COUNT(*), 0L)\n" +
-      "from DomainInfo d\n" +
-      "join Concept c ON d.domainId = c.domainId\n" +
-      "where (c.countValue > 0 or c.sourceCountValue > 0) and \n" +
-      "(matchConcept(c.conceptName, c.conceptCode, c.vocabularyId, c.synonymsStr, ?1) > 0 and\n" +
-      "c.standardConcept IN ('S', 'C')) or c.conceptId in (?3) or c.conceptCode = ?2\n" +
-      "group by d.domain, d.domainId, d.name, d.description, d.conceptId\n" +
-      "order by d.domainId")
+  @Query(nativeQuery=true,
+      value="select " +
+      "d.domain, d.domain_id, d.name, d.description, d.concept_id, " +
+      "0 all_concept_count, c.count standard_concept_count, 0 participant_count " +
+      "from domain_info d " +
+      "join (" +
+      "  select c1.domain_id, count(*) as count " +
+      "  from (" +
+      "    (select domain_id, concept_id from concept " +
+      "     where (count_value > 0 or source_count_value > 0) and " +
+      "       match(concept_name, concept_code, vocabulary_id, synonyms) against (?1 in boolean mode) > 0 and " +
+      "       standard_concept IN ('S', 'C')) " +
+      // An OR of these different conditions would be easier, but MySQL will not leverage the full
+      // text index to perform the match, bringing performance to a crawl (~10ms vs ~8s). Using the
+      // union results in usage of the fulltext index in the first subquery. In the future we should
+      // move these searches to a more suitable technology, e.g. Elasticsearch.
+      "    UNION DISTINCT " +
+      "    (select domain_id, concept_id from concept " +
+      "     where concept_id in (?3) or concept_code = ?2)) c1 " +
+      "  group by c1.domain_id) c " +
+      "ON d.domain_id = c.domain_id " +
+      "order by d.domain_id")
   List<DomainInfo> findStandardOrCodeMatchConceptCounts(String matchExpression, String query, List<Long> conceptIds);
 
   /**

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
@@ -36,11 +36,11 @@ public interface DomainInfoDao extends CrudRepository<DomainInfo, Long> {
       // move these searches to a more suitable technology, e.g. Elasticsearch.
       "    UNION DISTINCT " +
       "    (select domain_id, concept_id from concept " +
-      "     where concept_id in (?3) or concept_code = ?2)) c1 " +
+      "     where concept_id in (?2))) c1 " +
       "  group by c1.domain_id) c " +
       "ON d.domain_id = c.domain_id " +
       "order by d.domain_id")
-  List<DomainInfo> findStandardOrCodeMatchConceptCounts(String matchExpression, String query, List<Long> conceptIds);
+  List<DomainInfo> findStandardOrCodeMatchConceptCounts(String matchExpression, List<Long> conceptIds);
 
   /**
    * Returns domain metadata and concept counts for domains, matching only standard concepts by name,

--- a/performance/src/gatling/simulations/org/pmiops/databrowser/Pages.scala
+++ b/performance/src/gatling/simulations/org/pmiops/databrowser/Pages.scala
@@ -28,7 +28,7 @@ object Pages {
     val domainTotals: HttpRequestBuilder = http("domain-totals").get("/v1/databrowser/domain-totals")
     def domainSearch (searchTerm: String): HttpRequestBuilder = {
       def encodedTerm: String = URLEncoder.encode(searchTerm, StandardCharsets.UTF_8.toString).toLowerCase
-      http("domain-totals").get("/v1/databrowser/domain-totals?searchWord=" + encodedTerm)
+      http("domain-search").get("/v1/databrowser/domain-search?searchWord=" + encodedTerm)
     }
     def searchConcepts(postBody: String): HttpRequestBuilder = {
       http("search-concepts")

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -410,7 +410,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             toMatchConceptIds.addAll(drugMatchedConcepts.stream().map(Concept::getConceptId).collect(Collectors.toList()));
         }
 
-        List<DomainInfo> domains = domainInfoDao.findStandardOrCodeMatchConceptCounts(domainKeyword, query, toMatchConceptIds);
+        List<DomainInfo> domains = domainInfoDao.findStandardOrCodeMatchConceptCounts(domainKeyword, toMatchConceptIds);
         List<SurveyModule> surveyModules = surveyModuleDao.findSurveyModuleQuestionCounts(surveyKeyword);
         DomainInfosAndSurveyModulesResponse response = new DomainInfosAndSurveyModulesResponse();
         response.setDomainInfos(domains.stream()


### PR DESCRIPTION
This was the cleanest way I could find to force the query optimizer to do the right thing here. Basically the additional "or" predicates resulted in a full table scan, rather than using the full text index. In my direcdt SQL query experiments, this brought performance from ~8s -> ~10ms. Unfortunately the performance issue is not directly reproducible locally, since there are not as many synonyms loaded there.

In the future, we should move off FULLTEXT indexing since it seems to have a large number of performance issues / caveats.

Also adding @freemabd1  in case you have any additional MySQL insights here.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
