### PR TITLE
[DB-370][risk=no] Load test tweaks

### DIFF
--- a/performance/src/gatling/simulations/org/pmiops/databrowser/BasicSimulation.scala
+++ b/performance/src/gatling/simulations/org/pmiops/databrowser/BasicSimulation.scala
@@ -12,6 +12,7 @@ class BasicSimulation extends Simulation {
 
   val httpConf: HttpProtocolBuilder = http.
     baseUrl(config.defaultUrl).
+    disableCaching.
     userAgentHeader(config.userAgentHeader)
 
   def globalAssertions: List[Assertion] = List(
@@ -21,7 +22,7 @@ class BasicSimulation extends Simulation {
 
   setUp(
     Scenarios.configuredScenarios.map { cs =>
-      cs.builder.inject(rampUsers(cs.users) during cs.time)
+      cs.builder.inject(constantUsersPerSec(cs.users) during cs.time)
     })
     .assertions(globalAssertions)
     .protocols(httpConf)

--- a/performance/src/gatling/simulations/org/pmiops/databrowser/Configuration.scala
+++ b/performance/src/gatling/simulations/org/pmiops/databrowser/Configuration.scala
@@ -21,9 +21,8 @@ object Configuration {
     }
   }
   val userRampUpTimes: Map[Int, FiniteDuration] = Map(
-    10 -> (10 seconds),
-    100 -> (60 seconds),
-    1000 -> (120 seconds)
-  )
+    2 -> (10 seconds),
+    4 -> (1 minutes),
+    8 -> (2 minutes))
 
 }

--- a/performance/src/gatling/simulations/org/pmiops/databrowser/Pages.scala
+++ b/performance/src/gatling/simulations/org/pmiops/databrowser/Pages.scala
@@ -36,6 +36,11 @@ object Pages {
         .header("Content-Type", "application/json")
         .body(StringBody(postBody))
     }
+    def surveyModules (conceptId: String): HttpRequestBuilder = {
+      http("survey-results")
+        .get("/v1/databrowser/survey-results?survey_concept_id=" + conceptId)
+    }
+    val theBasics: HttpRequestBuilder = surveyModules("1586134")
   }
 
   object Home {
@@ -67,6 +72,11 @@ object Pages {
         .exec(APIs.searchConcepts(Json.stringify(postMap)))
         .pause(Configuration.defaultPause)
     }
+  }
+
+  object ViewSurveys {
+    val view: ChainBuilder = exec(APIs.config)
+      .exec(APIs.theBasics.check(status.is(session => 200)))
   }
 
 }

--- a/performance/src/gatling/simulations/org/pmiops/databrowser/Scenarios.scala
+++ b/performance/src/gatling/simulations/org/pmiops/databrowser/Scenarios.scala
@@ -13,6 +13,7 @@ case class ConfigurableScenario(name: String,
 
 sealed trait UserScenario { val name: String }
 case object HomePage extends UserScenario { val name = "Home Page" }
+case object Surveys extends UserScenario { val name = "Surveys" }
 case object UserStorySmoking extends UserScenario { val name = "User Story: Smoking" }
 
 /**
@@ -28,6 +29,9 @@ object Scenarios {
 
   val homePage: ScenarioBuilder = scenario(HomePage.name)
     .exec(Pages.Home.home)
+
+  val surveysPage: ScenarioBuilder = scenario(Surveys.name)
+    .exec(Pages.ViewSurveys.view)
 
   val searchSmoke: ScenarioBuilder = scenario(UserStorySmoking.name)
     .exec(Pages.Home.home)
@@ -45,9 +49,13 @@ object Scenarios {
     }
   }
 
-  val configuredScenarios: List[ConfigurableScenario] = List(
-    ConfigurableScenario(HomePage.name, homePage, 10, 10 seconds),
-    ConfigurableScenario(UserStorySmoking.name, searchSmoke, 10, 10 seconds)
-  ) ::: domainSearchApiScenarios
+  val configuredScenarios: List[ConfigurableScenario] = domainSearchApiScenarios ++
+    Configuration.userRampUpTimes.flatMap { t =>
+      List(
+        ConfigurableScenario(HomePage.name, homePage, t._1, t._2),
+        ConfigurableScenario(UserStorySmoking.name, searchSmoke, t._1, t._2),
+        ConfigurableScenario(Surveys.name, surveysPage, t._1, t._2)
+      )
+    }
 
 }


### PR DESCRIPTION
- Add a surveys scenario
- Disable caching
- Switch to constant user traffic
- Use the traffic variables across all scenarios

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
