### PR TITLE
[DB-444] [risk=no] removing security tag on api

### DIFF
--- a/public-api/src/main/resources/public-api.yaml
+++ b/public-api/src/main/resources/public-api.yaml
@@ -63,7 +63,6 @@ paths:
         - dataBrowser
       description: Gets the cdr versions
       operationId: "getCdrVersionUsed"
-      security: []
       parameters: []
       responses:
         200:


### PR DESCRIPTION
1. Removing security tag from the cdr version api.