### PR TITLE
[risk=no] Upgrade docker image, includes new GAE version, revert web.xml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 defaults: &defaults
   docker:
-    - image: allofustest/workbench:buildimage-0.0.12
+    - image: allofustest/workbench:buildimage-0.0.14
   working_directory: ~/data-browser
 java_defaults: &java_defaults
   <<: *defaults
@@ -18,7 +18,7 @@ java_defaults: &java_defaults
 jobs:
   public-api-local-test:
     docker:
-      - image: allofustest/workbench:buildimage-0.0.12
+      - image: allofustest/workbench:buildimage-0.0.14
       - image: mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=ubuntu

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   deploy:
-    image: allofustest/workbench:buildimage-0.0.13
+    image: allofustest/workbench:buildimage-0.0.14
     entrypoint: /bootstrap-docker.sh
     user: circleci
     environment:

--- a/public-api/src/main/webapp/WEB-INF/appengine-web.xml.template
+++ b/public-api/src/main/webapp/WEB-INF/appengine-web.xml.template
@@ -18,8 +18,8 @@
   </system-properties>
 
   <automatic-scaling>
-    <min-num-instances>${GAE_MIN_INSTANCES}</min-num-instances>
-    <max-num-instances>${GAE_MAX_INSTANCES}</max-num-instances>
+    <min-instances>${GAE_MIN_INSTANCES}</min-instances>
+    <max-instances>${GAE_MAX_INSTANCES}</max-instances>
   </automatic-scaling>
 </appengine-web-app>
 


### PR DESCRIPTION
My original PR was "correct", but our circle image was using an old version of the GAE SDK, which is why the property name failed originally. I rebuilt the image and it now matches we have locally.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
