### PR TITLE
[DB-343] [risk=no] survey page search event 

### DIFF
--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -637,6 +637,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
     public ResponseEntity<QuestionConceptListResponse> getSurveyResults(String surveyConceptId, String query, String routeUrl) {
         CdrVersionContext.setCdrVersionNoCheckAuthDomain(defaultCdrVersionProvider.get());
         //Trigger the search event for the search in any of the survey pages
+        //Since there is no way to trigger the event from the client side for now, hitting this api to trigger the event
         if (surveyConceptId == null && !Strings.isNullOrEmpty(query) && !Strings.isNullOrEmpty(routeUrl) && googleAnalyticsServiceImpl != null) {
             searchTrackEvent("DataBrowserSearch", "SurveySearch", query, routeUrl);
             QuestionConceptListResponse resp = new QuestionConceptListResponse();

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -500,7 +500,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
         }
 
         if (googleAnalyticsServiceImpl != null) {
-            searchTrackEvent("Search", "DomainSearch", query, routeUrl);
+            searchTrackEvent("DataBrowserSearch", "DomainSearch", query, routeUrl);
         }
         List<DomainInfo> domains = domainInfoDao.findStandardOrCodeMatchConceptCounts(domainKeyword, query, toMatchConceptIds);
         List<SurveyModule> surveyModules = surveyModuleDao.findSurveyModuleQuestionCounts(surveyKeyword);
@@ -537,7 +537,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
         }else{
             // This call triggers the event to post the data to google analytics endpoint
             if (googleAnalyticsServiceImpl != null) {
-                searchTrackEvent("Search", "ConceptSearch", searchConceptsRequest.getQuery(), routeUrl);
+                searchTrackEvent("DataBrowserSearch", "ConceptSearch", searchConceptsRequest.getQuery(), routeUrl);
             }
             if(standardConceptFilter == null){
                 standardConceptFilter = StandardConceptFilter.STANDARD_OR_CODE_ID_MATCH;
@@ -634,8 +634,14 @@ public class DataBrowserController implements DataBrowserApiDelegate {
     }
 
     @Override
-    public ResponseEntity<QuestionConceptListResponse> getSurveyResults(String surveyConceptId) {
+    public ResponseEntity<QuestionConceptListResponse> getSurveyResults(String surveyConceptId, String query, String routeUrl) {
         CdrVersionContext.setCdrVersionNoCheckAuthDomain(defaultCdrVersionProvider.get());
+        //Trigger the search event for the search in any of the survey pages
+        if (surveyConceptId == null && !Strings.isNullOrEmpty(query) && !Strings.isNullOrEmpty(routeUrl) && googleAnalyticsServiceImpl != null) {
+            searchTrackEvent("DataBrowserSearch", "SurveySearch", query, routeUrl);
+            QuestionConceptListResponse resp = new QuestionConceptListResponse();
+            return ResponseEntity.ok(resp);
+        }
         /* Set up the age and gender names */
         // Too slow and concept names wrong so we hardcode list
         // List<Concept> genders = conceptDao.findByConceptClassId("Gender");

--- a/public-api/src/main/resources/public-api.yaml
+++ b/public-api/src/main/resources/public-api.yaml
@@ -81,8 +81,18 @@ paths:
         - in: query
           name: survey_concept_id
           type: string
-          required: true
+          required: false
           description: survey concept id
+        - in: query
+          name: searchTerm
+          type: string
+          required: false
+          description: search term
+        - in: query
+          name: routeUrl
+          type: string
+          required: false
+          description: route url in which the event has occurred
       responses:
         200:
           description: A collection of survey modules

--- a/public-ui/src/app/views/survey-view/survey-view.component.ts
+++ b/public-ui/src/app/views/survey-view/survey-view.component.ts
@@ -89,7 +89,7 @@ export class SurveyViewComponent implements OnInit, OnDestroy {
   }
 
   private getSurveyResults() {
-    this.subscriptions.push(this.api.getSurveyResults(this.surveyConceptId.toString()).subscribe({
+    this.subscriptions.push(this.api.getSurveyResults(this.surveyConceptId.toString(), null, null).subscribe({
       next: x => {
         this.surveyResult = x;
         this.survey = this.surveyResult.survey;
@@ -262,6 +262,7 @@ export class SurveyViewComponent implements OnInit, OnDestroy {
     }
     if (this.searchText.value.length > 0) {
       this.questions = this.questions.filter(this.searchQuestion, this);
+      this.subscriptions.push(this.api.getSurveyResults(null, this.searchText.value, window.location.href).subscribe());
     }
     this.loading = false;
   }

--- a/public-ui/src/app/views/survey-view/survey-view.component.ts
+++ b/public-ui/src/app/views/survey-view/survey-view.component.ts
@@ -89,7 +89,8 @@ export class SurveyViewComponent implements OnInit, OnDestroy {
   }
 
   private getSurveyResults() {
-    this.subscriptions.push(this.api.getSurveyResults(this.surveyConceptId.toString(), null, null).subscribe({
+    this.subscriptions.push(this.api.getSurveyResults(this.surveyConceptId.toString(),
+      null, null).subscribe({
       next: x => {
         this.surveyResult = x;
         this.survey = this.surveyResult.survey;
@@ -262,7 +263,8 @@ export class SurveyViewComponent implements OnInit, OnDestroy {
     }
     if (this.searchText.value.length > 0) {
       this.questions = this.questions.filter(this.searchQuestion, this);
-      this.subscriptions.push(this.api.getSurveyResults(null, this.searchText.value, window.location.href).subscribe());
+      this.subscriptions.push(this.api.getSurveyResults(
+        null, this.searchText.value, window.location.href).subscribe());
     }
     this.loading = false;
   }


### PR DESCRIPTION
The survey pages fetch all the questions and answers before hand and then filter locally, so there is no way the search term change on client side to track. So hitting api to trigger the event with the empty response.