### PR TITLE
[risk=no] Move gender-count api call

### DIFF
--- a/public-ui/src/app/utils/db-config.service.ts
+++ b/public-ui/src/app/utils/db-config.service.ts
@@ -160,12 +160,14 @@ export class DbConfigService {
   };
 
   constructor(private api: DataBrowserService) {
+  }
+
+  getGenderAnalysisResults() {
     // Load up common simple data needed on pages
     // Get Demographic totals
     this.api.getGenderAnalysis().subscribe(result => {
       this.genderAnalysis = result;
     });
-
   }
 
   getPmGroups(): Observable<ConceptGroup[]> {

--- a/public-ui/src/app/views/quick-search/quick-search.component.ts
+++ b/public-ui/src/app/views/quick-search/quick-search.component.ts
@@ -60,6 +60,7 @@ export class QuickSearchComponent implements OnInit, OnDestroy {
     private router: Router,
     public dbc: DbConfigService,
     public tooltipText: TooltipService) {
+    this.dbc.getGenderAnalysisResults();
     this.route.params.subscribe(params => {
       this.dataType = params.dataType;
     });
@@ -69,7 +70,6 @@ export class QuickSearchComponent implements OnInit, OnDestroy {
     localStorage.removeItem('ehrDomain');
     localStorage.removeItem('surveyModule');
     localStorage.removeItem('searchText');
-    this.dbc.getGenderAnalysisResults();
     this.dbc.getPmGroups().subscribe(results => {
       this.pmConceptGroups = results;
       this.physicalMeasurementsFound = this.matchPhysicalMeasurements(this.prevSearchText);

--- a/public-ui/src/app/views/quick-search/quick-search.component.ts
+++ b/public-ui/src/app/views/quick-search/quick-search.component.ts
@@ -69,6 +69,7 @@ export class QuickSearchComponent implements OnInit, OnDestroy {
     localStorage.removeItem('ehrDomain');
     localStorage.removeItem('surveyModule');
     localStorage.removeItem('searchText');
+    this.dbc.getGenderAnalysisResults();
     this.dbc.getPmGroups().subscribe(results => {
       this.pmConceptGroups = results;
       this.physicalMeasurementsFound = this.matchPhysicalMeasurements(this.prevSearchText);


### PR DESCRIPTION
1. Moving the call in the landing page constructor (which is under the guard already).
2. I am not sure if this analysis is being used anywhere at all, might as well remove it soon.