### PR TITLE
[DB-525][risk=low] Only require signin for prod databrowser access

### DIFF
--- a/public-api/config/config_prod.json
+++ b/public-api/config/config_prod.json
@@ -3,7 +3,7 @@
   "auth": {
     "gsuiteDomain": "researchallofus.org",
     "requireSignIn": true,
-    "enforceRegistered": true
+    "enforceRegistered": false
   },
   "server": {
     "workbenchApiBaseUrl": "https:\/\/api.workbench.researchallofus.org",


### PR DESCRIPTION
Preparing this PR in case we move ahead with this option - needs security approval.

To apply this:
1. Merge thhis PR
2. Locally, pull master
3. `./project.rb update-cloud-config --project aou-db-prod`

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
