### PR TITLE
[DB-525][risk=low] Fix enforceRegistered check

### DIFF
--- a/public-api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
+++ b/public-api/src/main/java/org/pmiops/workbench/interceptors/AuthInterceptor.java
@@ -10,8 +10,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.pmiops.workbench.config.WorkbenchConfig;
 import org.pmiops.workbench.privateworkbench.PrivateWorkbenchService;
-import org.pmiops.workbench.privateworkbench.model.IdVerificationStatus;
 import org.pmiops.workbench.privateworkbench.model.Profile;
+import org.pmiops.workbench.privateworkbench.model.DataAccessLevel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.HttpHeaders;
@@ -83,8 +83,8 @@ public class AuthInterceptor extends HandlerInterceptorAdapter {
 
     Profile profile = privateWorkbenchService.getMe();
     if (config.auth.enforceRegistered &&
-        profile.getIdVerificationStatus() != IdVerificationStatus.VERIFIED) {
-      log.warning("Account has not been id verified");
+        profile.getDataAccessLevel() != DataAccessLevel.REGISTERED) {
+      log.warning("Account does not have registered access");
       response.sendError(HttpServletResponse.SC_FORBIDDEN);
       return false;
     }


### PR DESCRIPTION
Check dataAccessLevel rather than the deprecated idVerificationStatus field.

See also #239 , which makes this a non-issue (the code should still be updated here to match reality).

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
