### PR TITLE
[DB-361] [risk=no] removing the update search url changes and adding new prod config

### DIFF
--- a/public-api/config/cdr_versions_prod.json
+++ b/public-api/config/cdr_versions_prod.json
@@ -20,6 +20,6 @@
     "creationTime": "2018-11-13 15:09:27Z",
     "releaseNumber": 1,
     "numParticipants": 116460,
-    "publicDbName": "p_2019q1_6"
+    "publicDbName": "p_2019q1_7"
   }
 ]


### PR DESCRIPTION
1. Added new prod cdr version in config.
2. Removing the search param in the query param keeping sql injection attack in mind. Will revisit later.
