### PR TITLE
[DB-536] [risk=no] tooltip for q2 rolled into other

### DIFF
--- a/public-ui/src/app/utils/tooltip.service.ts
+++ b/public-ui/src/app/utils/tooltip.service.ts
@@ -122,6 +122,9 @@ export class TooltipService {
   Pacific Islander, or some other race. Survey respondents may report multiple races.
   Ethnicity determines whether a person is of Hispanic origin or not. Hispanics may report
   as any race.`;
+  q2RolledCategoriesHelpText = `“Other” includes the following categories: American Indian
+  or Alaska Native, Middle Eastern or North African,
+  Native Hawaiian or other Pacific Islander, and None of these describe me.`;
   constructor() { }
 
 }

--- a/public-ui/src/app/views/survey-view/survey-view.component.html
+++ b/public-ui/src/app/views/survey-view/survey-view.component.html
@@ -101,6 +101,12 @@
                       <div>
                         <app-highlight-search [text]="a.stratum4" [searchTerm]="searchText.value">
                         </app-highlight-search>
+                        <clr-tooltip *ngIf="q.conceptId === 1586140 && a.stratum3 === '903070'">
+                          <clr-icon clrTooltipTrigger shape="info-standard" class="is-solid info-icon"></clr-icon>
+                          <clr-tooltip-content clrPosition=bottom-right clrSize="lg" *clrIfOpen>
+                            <div class="tooltip-label">{{tooltipText.q2RolledCategoriesHelpText}}</div>
+                          </clr-tooltip-content>
+                        </clr-tooltip>
                       </div>
                     </div>
                     <div class="tbl-r-group">


### PR DESCRIPTION
1. Helptext for the category "other" in q2 to describe the fact that it has counts rolled up from american indian and such categories.