### PR TITLE
[DB-540] [risk=low] Removing duplicate age bin data

### DIFF
--- a/public-api/config/cdr_versions_stable.json
+++ b/public-api/config/cdr_versions_stable.json
@@ -22,6 +22,6 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "cdr20181101",
-    "publicDbName": "synth_p_2019q1_10"
+    "publicDbName": "synth_p_2019q1_11"
   }
 ]

--- a/public-api/config/cdr_versions_staging.json
+++ b/public-api/config/cdr_versions_staging.json
@@ -22,6 +22,6 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "cdr20181101",
-    "publicDbName": "synth_p_2019q1_10"
+    "publicDbName": "synth_p_2019q1_11"
   }
 ]

--- a/public-api/config/cdr_versions_test.json
+++ b/public-api/config/cdr_versions_test.json
@@ -10,6 +10,6 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "cdr20181023",
-    "publicDbName": "synth_p_2019q1_10"
+    "publicDbName": "synth_p_2019q1_11"
   }
 ]

--- a/public-api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/public-api/db-cdr/generate-cdr/make-bq-data.sh
@@ -614,19 +614,19 @@ group by d2.domain_id,c.vocabulary_id"
 ######################################
 echo "Updating rolled up counts of snomed conditions in concept"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"Update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
-set c.count_value=sub_cr.est_count
-from (select concept_id, est_count from \`$OUTPUT_PROJECT.$OUTPUT_DATASET.criteria\` cr
-where cr.concept_id = concept_id and cr.type='SNOMED' and cr.subtype='CM' and cr.synonyms like '%rank1%') as sub_cr
-where sub_cr.concept_id = c.concept_id and c.domain_id = 'Condition' and c.vocabulary_id = 'SNOMED' "
+"UPDATE \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
+SET c.count_value = cr.est_count
+FROM \`$OUTPUT_PROJECT.$OUTPUT_DATASET.criteria\` cr
+WHERE cr.concept_id=c.concept_id and cr.type='SNOMED' and cr.subtype='CM' and cr.synonyms like '%rank1%'
+and c.domain_id = 'Condition' and c.vocabulary_id = 'SNOMED' "
 
 echo "Updating rolled up counts of snomed procedures in concept"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"Update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
-set c.count_value=sub_cr.est_count
-from (select concept_id, est_count from \`$OUTPUT_PROJECT.$OUTPUT_DATASET.criteria\` cr
-where cr.concept_id = concept_id and cr.type='SNOMED' and cr.subtype='PCS' and cr.synonyms like '%rank1%') as sub_cr
-where sub_cr.concept_id = c.concept_id and c.domain_id = 'Procedure' and c.vocabulary_id = 'SNOMED' "
+"UPDATE \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
+SET c.count_value = cr.est_count
+FROM \`$OUTPUT_PROJECT.$OUTPUT_DATASET.criteria\` cr
+WHERE cr.concept_id=c.concept_id and cr.type='SNOMED' and cr.subtype='PCS' and cr.synonyms like '%rank1%'
+and c.domain_id = 'Procedure' and c.vocabulary_id = 'SNOMED' "
 
 ####################
 # criteria stratum #

--- a/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
+++ b/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
@@ -96,7 +96,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\` (id, analysis_id, stratum_1, count_value,source_count_value)
 with person_age as
 (select person_id,
-ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\`
 group by person_id,age
 )
@@ -277,7 +277,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
  (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with condition_age as
 (select condition_occurrence_id,
-ceil(TIMESTAMP_DIFF(condition_start_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(condition_start_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by condition_occurrence_id,age
 ),
@@ -318,7 +318,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -514,7 +514,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
 with procedure_age as
 (select procedure_occurrence_id,
-ceil(TIMESTAMP_DIFF(procedure_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(procedure_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by procedure_occurrence_id,age
 ),
@@ -556,7 +556,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
 with current_person_age as
 (select person_id,
-ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -695,7 +695,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with drug_age as
 (select drug_exposure_id,
-ceil(TIMESTAMP_DIFF(drug_exposure_start_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(drug_exposure_start_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by drug_exposure_id,age
 ),
@@ -737,7 +737,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -884,7 +884,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
 with ob_age as
 (select observation_id,
-ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -926,7 +926,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -1055,7 +1055,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with m_age as
 (select measurement_id,
-ceil(TIMESTAMP_DIFF(measurement_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(measurement_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by measurement_id,age
 ),
@@ -1097,7 +1097,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -1413,7 +1413,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1446,7 +1446,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1478,7 +1478,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1509,7 +1509,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1783,7 +1783,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1815,7 +1815,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
 with current_person_age as
 (select person_id,
-ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365.25) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),

--- a/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
+++ b/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
@@ -1236,20 +1236,6 @@ where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id i
 group by o.observation_source_concept_id,c.concept_name,sm.concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
-# Set the survey answer count for all the survey questions that belong to each module(value as number)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id,analysis_id,stratum_1,stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-SELECT 0 as id, 3110 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(o.value_as_number as string) as stratum_4,cast(sq.question_order_number as string) stratum_5,
-Count(distinct o.person_id) as count_value,0 as source_count_value
-FROM \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-Where (o.observation_source_concept_id > 0 and o.value_as_number >= 0 )
-Group by o.observation_source_concept_id,o.value_as_number,sm.concept_id,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
 # Survey question answers count by gender for all questions except basics q2
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
@@ -1263,7 +1249,7 @@ On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id > 0 and o.value_source_concept_id > 0 and o.observation_source_concept_id != 1586140)
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,o.value_as_number,c.concept_name,p.gender_concept_id,sq.question_order_number
+group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,p.gender_concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
 # Survey question answers count by gender for q2 unrolled
@@ -1279,7 +1265,7 @@ On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id not in (1586141,1586144,1586148,1586145,903070))
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,o.value_as_number,c.concept_name,p.gender_concept_id,sq.question_order_number
+group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,p.gender_concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
 # Survey question answers count by gender for q2 (rolling up categories)
@@ -1298,21 +1284,6 @@ where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id i
 group by sm.concept_id,o.observation_source_concept_id,c.concept_name,p.gender_concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
-
-# Survey question answers count by gender(value_as_number not null)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-select 0,3111 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(o.value_as_number as string) as stratum_4,CAST(p.gender_concept_id as string) as stratum_5,count(distinct p.person_id) as count_value,0 as source_count_value
-FROM \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (o.observation_source_concept_id > 0 and o.value_as_number >= 0 )
-group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,p.gender_concept_id,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
 # Survey question answers count by gender identity for all questions except q2
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
@@ -1327,7 +1298,7 @@ join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey
 join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id > 0 and o.value_source_concept_id > 0) and p.observation_source_concept_id=1585838
 and (o.observation_source_concept_id != 1586140)
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,o.value_as_number,c.concept_name,p.value_source_concept_id,sq.question_order_number
+group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,p.value_source_concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
 # Survey question answers count by gender identity for q2 unrolled categories
@@ -1343,7 +1314,7 @@ On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id =1586140 and o.value_source_concept_id not in (1586141,1586144,1586148,1586145,903070)) and p.observation_source_concept_id=1585838
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,o.value_as_number,c.concept_name,p.value_source_concept_id,sq.question_order_number
+group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,p.value_source_concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
 # Survey question answers count by gender identity for q2 rolled categories
@@ -1375,36 +1346,8 @@ On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id > 0 and o.value_source_concept_id > 0) and p.observation_source_concept_id=1586140
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,o.value_as_number,c.concept_name,p.value_source_concept_id,sq.question_order_number
+group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,p.value_source_concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
-
-# Survey question answers count by gender identity(value_as_number not null)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-select 0,3113 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(o.value_as_number as string) as stratum_4,CAST(p.value_source_concept_id as string) as stratum_5,count(distinct p.person_id) as count_value,0 as source_count_value
-FROM \`${BQ_PROJECT}.${BQ_DATASET}.observation\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (o.observation_source_concept_id > 0 and o.value_as_number >= 0) and p.observation_source_concept_id=1585838
-group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,p.value_source_concept_id,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc;"
-
-# Survey question answers count by race-ethnicity(value_as_number not null)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-select 0,3114 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(o.value_as_number as string) as stratum_4,CAST(p.value_source_concept_id as string) as stratum_5,count(distinct p.person_id) as count_value,0 as source_count_value
-FROM \`${BQ_PROJECT}.${BQ_DATASET}.observation\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (o.observation_source_concept_id > 0 and o.value_as_number >= 0) and p.observation_source_concept_id=1586140
-group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,p.value_source_concept_id,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc;"
 
 # Survey Question Answer Count by age deciles for all questions except q2
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
@@ -1500,38 +1443,6 @@ On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id in (1586141,1586144,1586148,1586145,903070))
 group by sm.concept_id,o.observation_source_concept_id,stratum_4,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-# Survey Question Answer Count by age deciles for questions that have value as number not null
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-with survey_age as
-(
-select observation_id,
-ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365.25) as age
-from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
-group by observation_id,age
-),
-survey_age_stratum as
-(
-select observation_id,
-case when age >= 18 and age <= 29 then '2'
-when age > 89 then '9'
-when age >= 30 and age <= 89 then cast(floor(age/10) as string)
-when age < 18 then '0' end as age_stratum from survey_age
-group by observation_id,age_stratum
-)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(o.value_as_number as string) as stratum_4,
-age_stratum as stratum_5,COUNT(distinct o.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join survey_age_stratum sa on sa.observation_id=o.observation_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
-where (o.observation_source_concept_id > 0 and o.value_as_number >= 0)
-group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,stratum_5,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
 if [[ "$tables" == *"_mapping_"* ]]; then

--- a/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
+++ b/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
@@ -49,7 +49,6 @@ tables=$(bq --project=$BQ_PROJECT --dataset=$BQ_DATASET ls)
 # Next Populate achilles_results
 echo "Running achilles queries..."
 
-
 echo "Getting person count"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
@@ -91,34 +90,28 @@ select 0, 5 as analysis_id,  CAST(ETHNICITY_CONCEPT_ID AS STRING) as stratum_1, 
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\`
 group by ETHNICITY_CONCEPT_ID"
 
-# 6	Number of persons by age decile 18-29
+# 6 Number of person by age decile
 echo "Getting age decile count"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\` (id, analysis_id, stratum_1, count_value,source_count_value)
-select 0, 6 as analysis_id,  '2' as stratum_2,
-COUNT(distinct person_id) as count_value, 0 as source_count_value
+with person_age as
+(select person_id,
+case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
+when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\`
-where (2019 - year_of_birth) >= 18 and (2019 - year_of_birth) < 30
-group by stratum_2"
-
-# 6	Number of persons by age decile 30-89
-echo "Getting age decile count"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\` (id, analysis_id, stratum_1, count_value,source_count_value)
-select 0, 6 as analysis_id,  CAST(floor((2019 - year_of_birth)/10) AS STRING) as stratum_2,
+group by person_id,age
+)
+select 0, 6 as analysis_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as stratum_2,
 COUNT(distinct person_id) as count_value, 0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\`
-where floor((2019 - year_of_birth)/10) >=3 and floor((2019 - year_of_birth)/10) < 9
-group by stratum_2"
-
-# 6	Number of persons by age decile 90+
-echo "Getting age decile count"
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\` (id, analysis_id, stratum_1, count_value,source_count_value)
-select 0, 6 as analysis_id,  CAST(floor((2019 - year_of_birth)/10) AS STRING) as stratum_2,
-COUNT(distinct person_id) as count_value, 0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\`
-where floor((2019 - year_of_birth)/10) >=9
+from person_age
 group by stratum_2"
 
 # 7 Gender identity count
@@ -278,171 +271,104 @@ and ob1.observation_source_concept_id=1586140
 group by co1.condition_source_concept_id, ob1.value_source_concept_id"
 
 # (400 age ) 3102 Number of persons with at least one condition occurrence, by condition_concept_id by age decile
-# Age Deciles : They will be  18-29 , 30-39, 40-49, 50-59, 60-69, 70-79, 80-89, 90+
+# Age Deciles : They will be  18-29 , 30-39, 40-49, 50-59, 60-69, 70-79, 80-89, 89+
 #  children are 0-17 and we don't have children for now .
 #Ex yob = 2000  , start date : 2017 -- , sd - yob = 17  / 10 = 1.7 floor(1.7 ) = 1
 # 30 - 39 , 2017 - 1980 = 37 / 10 = 3
 
-# Get the 30-39, 40 - 49 , ... groups
+# Get the age decile groups
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
  (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
+with condition_age as
+(select condition_occurrence_id,
+case when extract(month from condition_start_date) < (month_of_birth) and extract(day from condition_start_date) < (day_of_birth) then
+(DATE_DIFF(condition_start_date, extract(date from birth_datetime), year) -1)
+when extract(month from condition_start_date) > (month_of_birth) and extract(day from condition_start_date) > (day_of_birth) then
+(DATE_DIFF(condition_start_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(condition_start_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by condition_occurrence_id,age
+),
+condition_age_stratum as
+(
+select condition_occurrence_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from condition_age
+group by condition_occurrence_id,age_stratum
+)
 select 0, 3102 as analysis_id,
 CAST(co1.condition_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from condition_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-count(distinct p1.person_id) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2
-on p2.person_id=co2.person_id where co2.condition_source_concept_id=co1.condition_concept_id and floor((extract(year from co2.condition_start_date) - p2.year_of_birth)/10) >=3 and floor((extract(year from co2.condition_start_date) - p2.year_of_birth)/10) < 9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from condition_start_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from condition_start_date) - p1.year_of_birth)/10) < 9
-and co1.condition_concept_id > 0
-group by co1.condition_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,
-CAST(co1.condition_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from condition_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-COUNT(distinct p1.person_id) as count_value,
-COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id where floor((extract(year from condition_start_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from condition_start_date) - p1.year_of_birth)/10) < 9
-and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
-group by co1.condition_source_concept_id, stratum_2"
-
-#Get conditions by age decile id 3102 for the 18-29 group labeled as 2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
-select 0, 3102 as analysis_id,
-CAST(co1.condition_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Condition' as stratum_3,
- count(distinct p1.person_id) as count_value,(select COUNT(distinct p2.PERSON_ID) from
- \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2 on
- p2.person_id=co2.person_id where co2.condition_source_concept_id=co1.condition_concept_id
- and (extract(year from co2.condition_start_date) - p2.year_of_birth) > 18 and
- (extract(year from co2.condition_start_date) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id
-where (extract(year from condition_start_date) - p1.year_of_birth) > 18 and (extract(year from condition_start_date) - p1.year_of_birth) < 30
-and co1.condition_concept_id > 0
-group by co1.condition_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.condition_source_concept_id AS STRING) as stratum_1,'2' as stratum_2,'Condition' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from
-\`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id
-where (extract(year from condition_start_date) - p1.year_of_birth) > 18
-and (extract(year from condition_start_date) - p1.year_of_birth) < 30
-and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
-group by co1.condition_source_concept_id,stratum_2"
-
-# Get the 90+ condition age decile counts
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
- (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3102 as analysis_id,
-CAST(co1.condition_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from condition_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-count(distinct p1.person_id) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2
-on p2.person_id=co2.person_id where co2.condition_source_concept_id=co1.condition_concept_id and floor((extract(year from co2.condition_start_date) - p2.year_of_birth)/10) >=9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from condition_start_date) - p1.year_of_birth)/10) >=9
-and co1.condition_concept_id > 0
-group by co1.condition_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,
-CAST(co1.condition_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from condition_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-COUNT(distinct p1.person_id) as count_value,
-COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id where floor((extract(year from condition_start_date) - p1.year_of_birth)/10) >=9
-and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
-group by co1.condition_source_concept_id, stratum_2"
-
-
-# Get the 30-39, 40 - 49 , ... groups
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
- (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3106 as analysis_id,
-CAST(co1.condition_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-count(distinct p1.person_id) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2
-on p2.person_id=co2.person_id where co2.condition_source_concept_id=co1.condition_concept_id and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p2.year_of_birth)/10) < 9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.condition_concept_id > 0
-group by co1.condition_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,
-CAST(co1.condition_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-COUNT(distinct p1.person_id) as count_value,
-COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
-group by co1.condition_source_concept_id, stratum_2"
-
-# 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
- (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3106 as analysis_id,
-CAST(co1.condition_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-count(distinct p1.person_id) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2
-on p2.person_id=co2.person_id where co2.condition_source_concept_id=co1.condition_concept_id and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.condition_concept_id > 0
-group by co1.condition_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,
-CAST(co1.condition_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Condition' as stratum_3,
-COUNT(distinct p1.person_id) as count_value,
-COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
-group by co1.condition_source_concept_id, stratum_2"
-
-#Get conditions by age decile id 3106 for the 18-29 group labeled as 2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
-select 0, 3106 as analysis_id,
-CAST(co1.condition_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Condition' as stratum_3,
-count(distinct p1.person_id) as count_value,(select COUNT(distinct p2.PERSON_ID) from
-\`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2 on p2.person_id=co2.person_id
+age_stratum as stratum_2,
+'Condition' as stratum_3,
+count(distinct co1.person_id) as count_value,
+(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2 join condition_age_stratum ca2
+on co2.condition_occurrence_id = ca2.condition_occurrence_id
 where co2.condition_source_concept_id=co1.condition_concept_id
-and (extract(year from current_date()) - p2.year_of_birth) > 18 and
-(extract(year from current_date()) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
-on p1.person_id = co1.person_id
-where (extract(year from current_date()) - p1.year_of_birth) > 18 and (extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.condition_concept_id > 0
+and ca2.age_stratum=ca.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1 join condition_age_stratum ca on co1.condition_occurrence_id = ca.condition_occurrence_id
+where co1.condition_concept_id > 0
 group by co1.condition_concept_id, stratum_2
 union all
-select 0, 3106 as analysis_id,CAST(co1.condition_source_concept_id AS STRING) as stratum_1,'2' as stratum_2,'Condition' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
+select 0, 3102 as analysis_id,
+CAST(co1.condition_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Condition' as stratum_3,
+COUNT(distinct co1.person_id) as count_value,
+COUNT(distinct co1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1 join condition_age_stratum ca
+on co1.condition_occurrence_id = ca.condition_occurrence_id
+where co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
+group by co1.condition_source_concept_id, stratum_2"
+
+# Get the current age counts
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
+(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
+with current_person_age as
+(select person_id,
+case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
+when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
+group by person_id,age
+),
+current_person_age_stratum as
+(
+select person_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from current_person_age
+group by person_id,age_stratum
+)
+select 0, 3106 as analysis_id,
+CAST(co1.condition_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Condition' as stratum_3,
+count(distinct p1.person_id) as count_value,
+(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co2 join current_person_age_stratum p2
+on p2.person_id=co2.person_id
+where co2.condition_source_concept_id=co1.condition_concept_id
+and p2.age_stratum = p1.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where (extract(year from current_date()) - p1.year_of_birth) > 18 and (extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
-group by co1.condition_source_concept_id,stratum_2"
+where co1.condition_concept_id > 0
+group by co1.condition_concept_id, stratum_2
+union all
+select 0, 3106 as analysis_id,
+CAST(co1.condition_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Condition' as stratum_3,
+COUNT(distinct p1.person_id) as count_value,
+COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
+join current_person_age_stratum p1
+on p1.person_id = co1.person_id
+where co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
+group by co1.condition_source_concept_id, stratum_2"
 
 # No death data now per Kayla. Later when we have more data
 # 500	(3000) Number of persons with death, by cause_concept_id
@@ -601,165 +527,95 @@ group by co1.procedure_source_concept_id,ob1.value_source_concept_id"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
+with procedure_age as
+(select procedure_occurrence_id,
+case when extract(month from procedure_date) < (month_of_birth) and extract(day from procedure_date) < (day_of_birth) then
+(DATE_DIFF(procedure_date, extract(date from birth_datetime), year) -1)
+when extract(month from procedure_date) > (month_of_birth) and extract(day from procedure_date) > (day_of_birth) then
+(DATE_DIFF(procedure_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(procedure_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by procedure_occurrence_id,age
+),
+procedure_age_stratum as
+(
+select procedure_occurrence_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from procedure_age
+group by procedure_occurrence_id,age_stratum
+)
 select 0, 3102 as analysis_id,
 CAST(co1.procedure_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2
-on p2.person_id = co2.person_id where co2.procedure_source_concept_id=co1.procedure_concept_id
-and floor((extract(year from co2.procedure_date) - p2.year_of_birth)/10) >=3 and floor((extract(year from co2.procedure_date) - p2.year_of_birth)/10) <9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) <9
-and co1.procedure_concept_id > 0
-group by co1.procedure_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where (floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) <9)
-and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
-group by co1.procedure_source_concept_id, stratum_2"
-
-# 600 age 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
-select 0, 3102 as analysis_id,
-CAST(co1.procedure_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2
-on p2.person_id = co2.person_id where co2.procedure_source_concept_id=co1.procedure_concept_id
-and floor((extract(year from co2.procedure_date) - p2.year_of_birth)/10) >=9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) >=9
-and co1.procedure_concept_id > 0
-group by co1.procedure_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) >=9
-and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
-group by co1.procedure_source_concept_id, stratum_2"
-
-# 600 age 18-29
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3,count_value,source_count_value)
-select 0, 3102 as analysis_id,
-CAST(co1.procedure_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2
-on p2.person_id = co2.person_id where co2.procedure_source_concept_id=co1.procedure_concept_id
-and (extract(year from co2.procedure_date) - p2.year_of_birth) >= 18 and
-(extract(year from co2.procedure_date) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where (extract(year from co1.procedure_date) - p1.year_of_birth) >= 18 and
-(extract(year from co1.procedure_date) - p1.year_of_birth) < 30
-and co1.procedure_concept_id > 0
-group by co1.procedure_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,'2' as stratum_2,
+age_stratum as stratum_2,
 'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where (extract(year from co1.procedure_date) - p1.year_of_birth) >= 18 and
-(extract(year from co1.procedure_date) - p1.year_of_birth) < 30
-and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
+count(distinct co1.person_id) as count_value,
+(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2 join procedure_age_stratum ca2
+on co2.procedure_occurrence_id = ca2.procedure_occurrence_id
+where co2.procedure_source_concept_id=co1.procedure_concept_id
+and ca2.age_stratum=ca.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1 join procedure_age_stratum ca on co1.procedure_occurrence_id = ca.procedure_occurrence_id
+where co1.procedure_concept_id > 0
+group by co1.procedure_concept_id, stratum_2
+union all
+select 0, 3102 as analysis_id,
+CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Procedure' as stratum_3,
+COUNT(distinct co1.person_id) as count_value,
+COUNT(distinct co1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1 join procedure_age_stratum ca
+on co1.procedure_occurrence_id = ca.procedure_occurrence_id
+where co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
+and co1.procedure_source_concept_id > 0
 group by co1.procedure_source_concept_id, stratum_2"
 
 # 3106 current age histogram data
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
+with current_person_age as
+(select person_id,
+case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
+when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
+group by person_id,age
+),
+current_person_age_stratum as
+(
+select person_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from current_person_age
+group by person_id,age_stratum
+)
 select 0, 3106 as analysis_id,
 CAST(co1.procedure_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2 on p2.person_id = co2.person_id where co2.procedure_source_concept_id=co1.procedure_concept_id
-and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p2.year_of_birth)/10) <9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
+age_stratum as stratum_2,'Procedure' as stratum_3,
+count(distinct p1.person_id) as count_value,
+(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2 join current_person_age_stratum p2
+on p2.person_id=co2.person_id
+where co2.procedure_source_concept_id=co1.procedure_concept_id
+and p2.age_stratum = p1.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.procedure_concept_id > 0
+where co1.procedure_concept_id > 0
 group by co1.procedure_concept_id, stratum_2
 union all
-select 0, 3106 as analysis_id,CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
-group by co1.procedure_source_concept_id, stratum_2"
-
-# 3106 current age histogram data 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
 select 0, 3106 as analysis_id,
-CAST(co1.procedure_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2 on p2.person_id = co2.person_id where co2.procedure_source_concept_id=co1.procedure_concept_id
-and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
+CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Procedure' as stratum_3,
+COUNT(distinct p1.person_id) as count_value,
+COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.procedure_concept_id > 0
-group by co1.procedure_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
-group by co1.procedure_source_concept_id, stratum_2"
-
-# 3106 age 18-29
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3,count_value,source_count_value)
-select 0, 3106 as analysis_id,
-CAST(co1.procedure_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co2 on p2.person_id = co2.person_id where co2.procedure_source_concept_id=co1.procedure_concept_id
-and (extract(year from current_date()) - p2.year_of_birth) >= 18 and
-(extract(year from current_date()) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where (extract(year from current_date()) - p1.year_of_birth) >= 18 and
-(extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.procedure_concept_id > 0
-group by co1.procedure_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,CAST(co1.procedure_source_concept_id AS STRING) as stratum_1,'2' as stratum_2,
-'Procedure' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
-on p1.person_id = co1.person_id
-where (extract(year from current_date()) - p1.year_of_birth) >= 18 and
-(extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
+where co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
 group by co1.procedure_source_concept_id, stratum_2"
 
 # Drugs
@@ -862,159 +718,95 @@ group by co1.drug_source_concept_id,ob1.value_source_concept_id"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3102 as analysis_id,CAST(co1.drug_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 on p2.person_id = co2.person_id where co2.drug_source_concept_id=co1.drug_concept_id
-and floor((extract(year from co2.drug_exposure_start_date) - p2.year_of_birth)/10) >=3 and floor((extract(year from co2.drug_exposure_start_date) - p2.year_of_birth)/10) < 9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) < 9
-and co1.drug_concept_id > 0
-group by co1.drug_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.drug_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) < 9
-and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
-group by co1.drug_source_concept_id, stratum_2"
-
-# Drug age 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3102 as analysis_id,CAST(co1.drug_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 on p2.person_id = co2.person_id where co2.drug_source_concept_id=co1.drug_concept_id
-and floor((extract(year from co2.drug_exposure_start_date) - p2.year_of_birth)/10) >=9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) >=9
-and co1.drug_concept_id > 0
-group by co1.drug_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.drug_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) >=9
-and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
-group by co1.drug_source_concept_id, stratum_2"
-
-# Drug age decile
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
+with drug_age as
+(select drug_exposure_id,
+case when extract(month from drug_exposure_start_date) < (month_of_birth) and extract(day from drug_exposure_start_date) < (day_of_birth) then
+(DATE_DIFF(drug_exposure_start_date, extract(date from birth_datetime), year) -1)
+when extract(month from drug_exposure_start_date) > (month_of_birth) and extract(day from drug_exposure_start_date) > (day_of_birth) then
+(DATE_DIFF(drug_exposure_start_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(drug_exposure_start_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by drug_exposure_id,age
+),
+drug_age_stratum as
+(
+select drug_exposure_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from drug_age
+group by drug_exposure_id,age_stratum
+)
 select 0, 3102 as analysis_id,
 CAST(co1.drug_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 on p2.person_id = co2.person_id where co2.drug_source_concept_id=co1.drug_concept_id
-and (extract(year from co2.drug_exposure_start_date) - p2.year_of_birth) >= 18 and
-(extract(year from co2.drug_exposure_start_date) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where (extract(year from co1.drug_exposure_start_date) - p1.year_of_birth) >= 18 and
-(extract(year from co1.drug_exposure_start_date) - p1.year_of_birth) < 30
-and co1.drug_concept_id > 0
+age_stratum as stratum_2,
+'Drug' as stratum_3,
+count(distinct co1.person_id) as count_value,
+(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 join drug_age_stratum ca2
+on co2.drug_exposure_id = ca2.drug_exposure_id
+where co2.drug_source_concept_id=co1.drug_concept_id
+and ca2.age_stratum=ca.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1 join drug_age_stratum ca on co1.drug_exposure_id = ca.drug_exposure_id
+where co1.drug_concept_id > 0
 group by co1.drug_concept_id, stratum_2
 union all
-select 0, 3102 as analysis_id,CAST(co1.drug_source_concept_id AS STRING) as stratum_1,'2' as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where (extract(year from co1.drug_exposure_start_date) - p1.year_of_birth) >= 18 and
-(extract(year from co1.drug_exposure_start_date) - p1.year_of_birth) < 30
-and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
+select 0, 3102 as analysis_id,
+CAST(co1.drug_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Drug' as stratum_3,
+COUNT(distinct co1.person_id) as count_value,
+COUNT(distinct co1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1 join drug_age_stratum ca
+on co1.drug_exposure_id = ca.drug_exposure_id
+where co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
+and co1.drug_source_concept_id > 0
 group by co1.drug_source_concept_id, stratum_2"
 
 # 3106 Drug current age
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3106 as analysis_id,CAST(co1.drug_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 on p2.person_id = co2.person_id where co2.drug_source_concept_id=co1.drug_concept_id
-and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p2.year_of_birth)/10) < 9 ) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.drug_concept_id > 0
-group by co1.drug_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,CAST(co1.drug_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
-group by co1.drug_source_concept_id, stratum_2"
-
-# 3106 Drug current age 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3106 as analysis_id,CAST(co1.drug_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 on p2.person_id = co2.person_id where co2.drug_source_concept_id=co1.drug_concept_id
-and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=9 ) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.drug_concept_id > 0
-group by co1.drug_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,CAST(co1.drug_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
-on p1.person_id = co1.person_id
-where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
-group by co1.drug_source_concept_id, stratum_2"
-
-# 3106 Drug current age decile 2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
+with current_person_age as
+(select person_id,
+case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
+when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
+group by person_id,age
+),
+current_person_age_stratum as
+(
+select person_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from current_person_age
+group by person_id,age_stratum
+)
 select 0, 3106 as analysis_id,
 CAST(co1.drug_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 on
-p2.person_id = co2.person_id where co2.drug_source_concept_id=co1.drug_concept_id
-and (extract(year from current_date()) - p2.year_of_birth) >= 18 and
-(extract(year from current_date()) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
+age_stratum as stratum_2,'Drug' as stratum_3,
+count(distinct p1.person_id) as count_value,
+(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co2 join current_person_age_stratum p2
+on p2.person_id=co2.person_id
+where co2.drug_source_concept_id=co1.drug_concept_id
+and p2.age_stratum = p1.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where (extract(year from current_date()) - p1.year_of_birth) >= 18 and
-(extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.drug_concept_id > 0
+where co1.drug_concept_id > 0
 group by co1.drug_concept_id, stratum_2
 union all
-select 0, 3106 as analysis_id,CAST(co1.drug_source_concept_id AS STRING) as stratum_1,'2' as stratum_2,'Drug' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
+select 0, 3106 as analysis_id,
+CAST(co1.drug_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Drug' as stratum_3,
+COUNT(distinct p1.person_id) as count_value,
+COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where (extract(year from current_date()) - p1.year_of_birth) >= 18 and
-(extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
+where co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
 group by co1.drug_source_concept_id, stratum_2"
 
 # 800	(3000) Number of persons with at least one observation occurrence, by observation_concept_id
@@ -1125,171 +917,96 @@ group by co1.observation_source_concept_id, ob1.value_source_concept_id"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
+with ob_age as
+(select observation_id,
+case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
+when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by observation_id,age
+),
+ob_age_stratum as
+(
+select observation_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from ob_age
+group by observation_id,age_stratum
+)
 select 0, 3102 as analysis_id,
 CAST(co1.observation_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id
+age_stratum as stratum_2,
+'Observation' as stratum_3,
+count(distinct co1.person_id) as count_value,
+(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join ob_age_stratum ca2
+on co2.observation_id = ca2.observation_id
 where co2.observation_source_concept_id=co1.observation_concept_id
-and floor((extract(year from co2.observation_date) - p2.year_of_birth)/10) >=3 and floor((extract(year from co2.observation_date) - p2.year_of_birth)/10) < 9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) < 9
+and ca2.age_stratum=ca.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1 join ob_age_stratum ca on co1.observation_id = ca.observation_id
+where co1.observation_concept_id > 0
 group by co1.observation_concept_id, stratum_2
 union all
-select 0, 3102 as analysis_id,CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_source_concept_id > 0 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) < 9
-and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
-group by co1.observation_source_concept_id, stratum_2
-"
-
-# Observation (3102)	Number of persons with   concept id by  age decile  90+ yr old deciles
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
 select 0, 3102 as analysis_id,
-CAST(co1.observation_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id
-where co2.observation_source_concept_id=co1.observation_concept_id
-and floor((extract(year from co2.observation_date) - p2.year_of_birth)/10) >=9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) >=9
-group by co1.observation_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_source_concept_id > 0 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) >=9
-and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
-group by co1.observation_source_concept_id, stratum_2
-"
-
-# Observation (3102)	Number of persons with concept id by  age decile  < 20 yr old decile 1
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3102 as analysis_id,
-CAST(co1.observation_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id where co2.observation_source_concept_id=co1.observation_concept_id
-and (extract(year from co2.observation_date) - p2.year_of_birth) >= 18 and (extract(year from co2.observation_date) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and (extract(year from co1.observation_date) - p1.year_of_birth) >= 18 and (extract(year from co1.observation_date) - p1.year_of_birth) < 30
-group by co1.observation_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and (extract(year from co1.observation_date) - p1.year_of_birth) >= 18 and (extract(year from co1.observation_date) - p1.year_of_birth) < 30
-and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
-group by co1.observation_source_concept_id, stratum_2
-"
+CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Observation' as stratum_3,
+COUNT(distinct co1.person_id) as count_value,
+COUNT(distinct co1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1 join ob_age_stratum ca
+on co1.observation_id = ca.observation_id
+where co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
+and co1.observation_source_concept_id > 0
+group by co1.observation_source_concept_id, stratum_2 "
 
 # Observation (3106)	Number of persons with   concept id by  current age decile  30+ yr old deciles
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
+with current_person_age as
+(select person_id,
+case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
+when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
+group by person_id,age
+),
+current_person_age_stratum as
+(
+select person_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from current_person_age
+group by person_id,age_stratum
+)
 select 0, 3106 as analysis_id,
 CAST(co1.observation_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id
+age_stratum as stratum_2,'Observation' as stratum_3,
+count(distinct p1.person_id) as count_value,
+(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join current_person_age_stratum p2
+on p2.person_id=co2.person_id
 where co2.observation_source_concept_id=co1.observation_concept_id
-and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p2.year_of_birth)/10) < 9 ) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
+and p2.age_stratum = p1.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
+where co1.observation_concept_id > 0
 group by co1.observation_concept_id, stratum_2
 union all
-select 0, 3106 as analysis_id,CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_source_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
-group by co1.observation_source_concept_id, stratum_2
-"
-
-# Observation (3106)	Number of persons with   concept id by  current age decile  30+ yr old deciles
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
 select 0, 3106 as analysis_id,
-CAST(co1.observation_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id
-where co2.observation_source_concept_id=co1.observation_concept_id
-and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=9 ) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
+CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
+age_stratum as stratum_2,'Observation' as stratum_3,
+COUNT(distinct p1.person_id) as count_value,
+COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-group by co1.observation_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_source_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
-group by co1.observation_source_concept_id, stratum_2
-"
-
-# Observation (3106)	Number of persons with concept id by current age decile  18 - 29 yr old decile 2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3106 as analysis_id,
-CAST(co1.observation_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id where co2.observation_source_concept_id=co1.observation_concept_id
-and (extract(year from current_date()) - p2.year_of_birth) >= 18 and (extract(year from current_date()) - p2.year_of_birth) < 30) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and (extract(year from current_date()) - p1.year_of_birth) >= 18 and (extract(year from current_date()) - p1.year_of_birth) < 30
-group by co1.observation_concept_id, stratum_2
-union all
-select 0, 3106 as analysis_id,CAST(co1.observation_source_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Observation' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
-on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and (extract(year from current_date()) - p1.year_of_birth) >= 18 and (extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
-group by co1.observation_source_concept_id, stratum_2
-"
+where co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
+group by co1.observation_source_concept_id, stratum_2"
 
 # Measurement concept by gender
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
@@ -1381,114 +1098,95 @@ group by co1.measurement_source_concept_id, ob1.value_source_concept_id"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
+with m_age as
+(select measurement_id,
+case when extract(month from measurement_date) < (month_of_birth) and extract(day from measurement_date) < (day_of_birth) then
+(DATE_DIFF(measurement_date, extract(date from birth_datetime), year) -1)
+when extract(month from measurement_date) > (month_of_birth) and extract(day from measurement_date) > (day_of_birth) then
+(DATE_DIFF(measurement_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(measurement_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by measurement_id,age
+),
+m_age_stratum as
+(
+select measurement_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from m_age
+group by measurement_id,age_stratum
+)
 select 0, 3102 as analysis_id,
 CAST(co1.measurement_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.person_id) from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id where co2.measurement_source_concept_id=co1.measurement_concept_id
-and floor((extract(year from co2.measurement_date) - p2.year_of_birth)/10) >=3 and floor((extract(year from co2.measurement_date) - p2.year_of_birth)/10) < 9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
-on p1.person_id = co1.person_id
-where co1.measurement_concept_id > 0 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) < 9
+age_stratum as stratum_2,
+'Measurement' as stratum_3,
+count(distinct co1.person_id) as count_value,
+(select COUNT(distinct co2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co2 join m_age_stratum ca2
+on co2.measurement_id = ca2.measurement_id
+where co2.measurement_source_concept_id=co1.measurement_concept_id
+and ca2.age_stratum=ca.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1 join m_age_stratum ca on co1.measurement_id = ca.measurement_id
+where co1.measurement_concept_id > 0
 group by co1.measurement_concept_id, stratum_2
 union all
 select 0, 3102 as analysis_id,
 CAST(co1.measurement_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
-on p1.person_id = co1.person_id
-where co1.measurement_source_concept_id > 0 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) < 9
-and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
+age_stratum as stratum_2,'Measurement' as stratum_3,
+COUNT(distinct co1.person_id) as count_value,
+COUNT(distinct co1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1 join m_age_stratum ca
+on co1.measurement_id = ca.measurement_id
+where co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
+and co1.measurement_source_concept_id > 0
 group by co1.measurement_source_concept_id, stratum_2"
-
-# Measurement by age deciles 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3102 as analysis_id,
-CAST(co1.measurement_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.person_id) from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id where co2.measurement_source_concept_id=co1.measurement_concept_id
-and floor((extract(year from co2.measurement_date) - p2.year_of_birth)/10) >=9) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
-on p1.person_id = co1.person_id
-where co1.measurement_concept_id > 0 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) >=9
-group by co1.measurement_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,
-CAST(co1.measurement_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
-on p1.person_id = co1.person_id
-where co1.measurement_source_concept_id > 0 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) >=9
-and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
-group by co1.measurement_source_concept_id, stratum_2"
-
-# Measurement  18 - 29 yr old decile 2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
-select 0, 3102 as analysis_id,
-CAST(co1.measurement_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.person_id) from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2
-on p2.person_id=co2.person_id where co2.measurement_source_concept_id=co1.measurement_concept_id
-and (extract(year from co2.measurement_date) - p2.year_of_birth) >= 18 and (extract(year from co2.measurement_date) - p2.year_of_birth) < 30 ) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
-on p1.person_id = co1.person_id
-where co1.measurement_concept_id > 0 and (extract(year from co1.measurement_date) - p1.year_of_birth) >= 18 and (extract(year from co1.measurement_date) - p1.year_of_birth) < 30
-group by co1.measurement_concept_id, stratum_2
-union all
-select 0, 3102 as analysis_id,
-CAST(co1.measurement_source_concept_id AS STRING) as stratum_1,
-'2' as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
-on p1.person_id = co1.person_id
-where co1.measurement_source_concept_id > 0 and (extract(year from co1.measurement_date) - p1.year_of_birth) >= 18 and (extract(year from co1.measurement_date) - p1.year_of_birth) < 30
-and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
-group by co1.measurement_source_concept_id, stratum_2
-"
 
 # 3106 Measurement by current age deciles
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
+with current_person_age as
+(select person_id,
+case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
+when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
+group by person_id,age
+),
+current_person_age_stratum as
+(
+select person_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from current_person_age
+group by person_id,age_stratum
+)
 select 0, 3106 as analysis_id,
 CAST(co1.measurement_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-(select COUNT(distinct co2.person_id) from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id where co2.measurement_source_concept_id=co1.measurement_concept_id
-and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p2.year_of_birth)/10) < 9 ) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
+age_stratum as stratum_2,'Measurement' as stratum_3,
+count(distinct p1.person_id) as count_value,
+(select COUNT(distinct p2.PERSON_ID) from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co2 join current_person_age_stratum p2
+on p2.person_id=co2.person_id
+where co2.measurement_source_concept_id=co1.measurement_concept_id
+and p2.age_stratum = p1.age_stratum) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where co1.measurement_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
+where co1.measurement_concept_id > 0
 group by co1.measurement_concept_id, stratum_2
 union all
 select 0, 3106 as analysis_id,
 CAST(co1.measurement_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,
-COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
+age_stratum as stratum_2,'Measurement' as stratum_3,
+COUNT(distinct p1.person_id) as count_value,
+COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
+join current_person_age_stratum p1
 on p1.person_id = co1.person_id
-where co1.measurement_source_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
+where co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
 group by co1.measurement_source_concept_id, stratum_2"
 
 # 3106 Measurement by current age deciles 90+
@@ -1497,7 +1195,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 select 0, 3106 as analysis_id,
 CAST(co1.measurement_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
+'9' as stratum_2,'Measurement' as stratum_3,
 COUNT(distinct p1.PERSON_ID) as count_value,
 (select COUNT(distinct co2.person_id) from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co2 join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p2 on p2.person_id=co2.person_id where co2.measurement_source_concept_id=co1.measurement_concept_id
 and floor((extract(year from current_date()) - p2.year_of_birth)/10) >=9 ) as source_count_value
@@ -1509,7 +1207,7 @@ group by co1.measurement_concept_id, stratum_2
 union all
 select 0, 3106 as analysis_id,
 CAST(co1.measurement_source_concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,'Measurement' as stratum_3,
+'9' as stratum_2,'Measurement' as stratum_3,
 COUNT(distinct p1.PERSON_ID) as count_value,
 COUNT(distinct p1.PERSON_ID) as source_count_value
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
@@ -1583,7 +1281,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id,analysis_id,stratum_1,stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
 SELECT 0 as id, 3110 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(903070 as string) as stratum_3,c.concept_name as stratum_4,cast(sq.question_order_number as string) stratum_5,
+CAST(903070 as string) as stratum_3,'Other' as stratum_4,cast(sq.question_order_number as string) stratum_5,
 Count(distinct o.person_id) as count_value, 0 as source_count_value
 FROM \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
 On o.observation_source_concept_id=sq.question_concept_id
@@ -1644,7 +1342,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
 select 0,3111 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(903070 as string) as stratum_3,c.concept_name as stratum_4,
+CAST(903070 as string) as stratum_3,'Other' as stratum_4,
 CAST(p.gender_concept_id as string) as stratum_5,count(distinct p.person_id) as count_value,0 as source_count_value
 FROM \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
@@ -1708,7 +1406,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
 select 0,3113 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(903070 as string) as stratum_3,c.concept_name as stratum_4,
+CAST(903070 as string) as stratum_3,'Other' as stratum_4,
 CAST(p.value_source_concept_id as string) as stratum_5,count(distinct p.person_id) as count_value,0 as source_count_value
 FROM \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` p on p.person_id = o.person_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
@@ -1763,210 +1461,151 @@ where (o.observation_source_concept_id > 0 and o.value_as_number >= 0) and p.obs
 group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,p.value_source_concept_id,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc;"
 
-# Survey Question Answer Count by age decile  30+ yr old deciles for all questions except q2
+# Survey Question Answer Count by age deciles for all questions except q2
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
+with survey_age as
+(
+select observation_id,
+case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
+when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by observation_id,age
+),
+survey_age_stratum as
+(
+select observation_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from survey_age
+group by observation_id,age_stratum
+)
 select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
 CAST(o.value_source_concept_id as string) as stratum_3,c.concept_name as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
+age_stratum as stratum_5,COUNT(distinct o.PERSON_ID) as count_value,0 as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join survey_age_stratum sa on sa.observation_id=o.observation_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
 On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id > 0 and o.value_source_concept_id > 0)
 and o.observation_source_concept_id != 1586140
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=3 and floor((extract(year from o.observation_date) - p.year_of_birth)/10) < 9
 group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
-# Survey Question Answer Count by age decile  30+ yr old deciles for q2 unrolled categories
+# Survey Question Answer Count by age deciles for unrolled categories in q2
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
+with survey_age as
+(
+select observation_id,
+case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
+when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by observation_id,age
+),
+survey_age_stratum as
+(
+select observation_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from survey_age
+group by observation_id,age_stratum
+)
 select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
 CAST(o.value_source_concept_id as string) as stratum_3,c.concept_name as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
+age_stratum as stratum_5,COUNT(distinct o.PERSON_ID) as count_value,0 as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join survey_age_stratum sa on sa.observation_id=o.observation_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
 On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id not in (1586141,1586144,1586148,1586145,903070))
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=3 and floor((extract(year from o.observation_date) - p.year_of_birth)/10) < 9
 group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
-# Survey Question Answer Count by age decile  30+ yr old deciles for q2 rolled categories
+# Survey Question Answer Count by age deciles for rolled categories in q2
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
+with survey_age as
+(
+select observation_id,
+case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
+when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by observation_id,age
+),
+survey_age_stratum as
+(
+select observation_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from survey_age
+group by observation_id,age_stratum
+)
 select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(903070 as string) as stratum_3,c.concept_name as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
+'903070' as stratum_3,'Other' as stratum_4,
+age_stratum as stratum_5,COUNT(distinct o.PERSON_ID) as count_value,0 as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join survey_age_stratum sa on sa.observation_id=o.observation_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
 On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = 903070
 where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id in (1586141,1586144,1586148,1586145,903070))
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=3 and floor((extract(year from o.observation_date) - p.year_of_birth)/10) < 9
-group by sm.concept_id,o.observation_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
+group by sm.concept_id,o.observation_source_concept_id,stratum_4,stratum_5,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
-# Survey Question Answer Count by age decile  90+ yr old deciles for all questions except q2 in basics
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(o.value_source_concept_id as string) as stratum_3,c.concept_name as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
-where (o.observation_source_concept_id > 0 and o.value_source_concept_id > 0 and o.observation_source_concept_id != 1586140)
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=9
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-# Survey Question Answer Count by age decile  90+ yr old deciles for unrolled categories of q2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(o.value_source_concept_id as string) as stratum_3,c.concept_name as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
-where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id not in (1586141,1586144,1586148,1586145,903070))
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=9
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-# Survey Question Answer Count by age decile  90+ yr old deciles for rolled categories of q2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
-CAST(903070 as string) as stratum_3,c.concept_name as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = 903070
-where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id in (1586141,1586144,1586148,1586145,903070))
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=9
-group by sm.concept_id,o.observation_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-# Survey Question Answer Count by age decile 18-30 yr old decile 1 for all questions except q2 basics
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,
-CAST(o.observation_source_concept_id as string) as stratum_2,CAST(o.value_source_concept_id as string) as stratum_3,
-c.concept_name as stratum_4,
-'2' as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
-where (o.observation_source_concept_id > 0 and o.value_source_concept_id > 0 and o.observation_source_concept_id != 1586140)
-and (extract(year from o.observation_date) - p.year_of_birth) >= 18 and (extract(year from o.observation_date) - p.year_of_birth) < 30
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-# Survey Question Answer Count by age decile  18-30 yr old decile 1 for unrolled categories of q2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,
-CAST(o.observation_source_concept_id as string) as stratum_2,CAST(o.value_source_concept_id as string) as stratum_3,
-c.concept_name as stratum_4,
-'2' as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
-where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id not in (1586141,1586144,1586148,1586145,903070))
-and (extract(year from o.observation_date) - p.year_of_birth) >= 18 and (extract(year from o.observation_date) - p.year_of_birth) < 30
-group by sm.concept_id,o.observation_source_concept_id,o.value_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-# Survey Question Answer Count by age decile 18-30 yr old decile 1 for rolled categories of q2
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_3,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,
-CAST(o.observation_source_concept_id as string) as stratum_2,CAST(903070 as string) as stratum_3,
-c.concept_name as stratum_4,
-'2' as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = 903070
-where (o.observation_source_concept_id = 1586140 and o.value_source_concept_id in (1586141,1586144,1586148,1586145,903070))
-and (extract(year from o.observation_date) - p.year_of_birth) >= 18 and (extract(year from o.observation_date) - p.year_of_birth) < 30
-group by sm.concept_id,o.observation_source_concept_id,c.concept_name,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-
-# Survey Question Answer Count by age decile  30+ yr old deciles(value as number not null)
+# Survey Question Answer Count by age deciles for questions that have value as number not null
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id, analysis_id, stratum_1, stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,
-CAST(o.observation_source_concept_id as string) as stratum_2,CAST(o.value_as_number as string) as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
+with survey_age as
+(
+select observation_id,
+case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
+when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by observation_id,age
+),
+survey_age_stratum as
+(
+select observation_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from survey_age
+group by observation_id,age_stratum
+)
+select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,CAST(o.observation_source_concept_id as string) as stratum_2,
+CAST(o.value_as_number as string) as stratum_4,
+age_stratum as stratum_5,COUNT(distinct o.PERSON_ID) as count_value,0 as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o join survey_age_stratum sa on sa.observation_id=o.observation_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
 On o.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
+join \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c on c.concept_id = o.value_source_concept_id
 where (o.observation_source_concept_id > 0 and o.value_as_number >= 0)
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=3 and floor((extract(year from o.observation_date) - p.year_of_birth)/10) < 9
-group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-# Survey Question Answer Count by age decile  90+ yr old deciles(value as number not null)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,
-CAST(o.observation_source_concept_id as string) as stratum_2,CAST(o.value_as_number as string) as stratum_4,
-CAST(floor((extract(year from o.observation_date) - p.year_of_birth)/10) AS STRING) as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (o.observation_source_concept_id > 0 and o.value_as_number >= 0)
-and floor((extract(year from o.observation_date) - p.year_of_birth)/10) >=9
-group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,stratum_5,sq.question_order_number
-order by CAST(sq.question_order_number as int64) asc"
-
-
-# Survey Question Answer Count by age decile 18-30 yr old decile 1(value as number not null)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id, analysis_id, stratum_1, stratum_2,stratum_4,stratum_5,count_value,source_count_value)
-select 0, 3112 as analysis_id,CAST(sm.concept_id as string) as stratum_1,
-CAST(o.observation_source_concept_id as string) as stratum_2,CAST(o.value_as_number as string) as stratum_4,
-'2' as stratum_5,COUNT(distinct p.PERSON_ID) as count_value,0 as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p inner join \`${BQ_PROJECT}.${BQ_DATASET}.observation\` o on p.person_id = o.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On o.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (o.observation_source_concept_id > 0 and o.value_as_number >= 0 )
-and (extract(year from o.observation_date) - p.year_of_birth) >= 18 and (extract(year from o.observation_date) - p.year_of_birth) < 30
 group by sm.concept_id,o.observation_source_concept_id,o.value_as_number,stratum_5,sq.question_order_number
 order by CAST(sq.question_order_number as int64) asc"
 
@@ -2216,116 +1855,75 @@ group by sm.concept_id, p1.value_source_concept_id"
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
+with survey_age as
+(
+select observation_id,
+case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
+when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
+group by observation_id,age
+),
+survey_age_stratum as
+(
+select observation_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from survey_age
+group by observation_id,age_stratum
+)
 select 0, 3102 as analysis_id,
 CAST(sm.concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,
+age_stratum as stratum_2,
   'Survey' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1
-on p1.person_id = ob1.person_id
+COUNT(distinct ob1.PERSON_ID) as count_value,COUNT(distinct ob1.PERSON_ID) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1 join survey_age_stratum sa on
+sa.observation_id = ob1.observation_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
 On ob1.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 where (ob1.observation_source_concept_id > 0 and ob1.value_source_concept_id > 0)
-and floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) < 9
-group by sm.concept_id, stratum_2"
-
-# Age breakdown of people who took each survey (Row for combinations of each survey and age decile) 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
-select 0, 3102 as analysis_id,
-CAST(sm.concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) AS STRING) as stratum_2,
-  'Survey' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1
-on p1.person_id = ob1.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On ob1.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (ob1.observation_source_concept_id > 0 and ob1.value_source_concept_id > 0)
-and floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) >=9
-group by sm.concept_id, stratum_2"
-
-# Age breakdown of people who took each survey (Row for combinations of each survey and age decile 2)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
-select 0, 3102 as analysis_id,
-CAST(sm.concept_id AS STRING) as stratum_1,
-'2' as stratum_2,
-  'Survey' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1
-on p1.person_id = ob1.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On ob1.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (ob1.observation_source_concept_id > 0 and ob1.value_source_concept_id > 0)
-and (extract(year from ob1.observation_date) - p1.year_of_birth) >= 18 and (extract(year from ob1.observation_date) - p1.year_of_birth) < 30
-group by sm.concept_id, stratum_2"
+group by sm.concept_id, stratum_2;"
 
 # Current Age breakdown of people who took each survey (Row for combinations of each survey and age decile)
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
 (id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
+with current_person_age as
+(select person_id,
+case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
+when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
+else
+(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
+group by person_id,age
+),
+current_person_age_stratum as
+(
+select person_id,
+case when age >= 18 and age <= 29 then '2'
+when age > 89 then '9'
+when age >= 30 and age <= 89 then cast(floor(age/10) as string)
+when age < 18 then '0' end as age_stratum from current_person_age
+group by person_id,age_stratum
+)
 select 0, 3106 as analysis_id,
 CAST(sm.concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,
+ca.age_stratum as stratum_2,
   'Survey' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1
-on p1.person_id = ob1.person_id
+COUNT(distinct ob1.PERSON_ID) as count_value,COUNT(distinct ob1.PERSON_ID) as source_count_value
+from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1 join current_person_age_stratum ca on ca.person_id=ob1.person_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
 On ob1.observation_source_concept_id=sq.question_concept_id
 join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
 where (ob1.observation_source_concept_id > 0 and ob1.value_source_concept_id > 0)
-and floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) < 9
 group by sm.concept_id, stratum_2"
-
-# Current Age breakdown of people who took each survey (Row for combinations of each survey and age decile) 90+
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
-select 0, 3106 as analysis_id,
-CAST(sm.concept_id AS STRING) as stratum_1,
-CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING) as stratum_2,
-  'Survey' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1
-on p1.person_id = ob1.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On ob1.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (ob1.observation_source_concept_id > 0 and ob1.value_source_concept_id > 0)
-and floor((extract(year from ob1.observation_date) - p1.year_of_birth)/10) >=9
-group by sm.concept_id, stratum_2"
-
-# Current age breakdown of people who took each survey (Row for combinations of each survey and age decile 2)
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\`
-(id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
-select 0, 3106 as analysis_id,
-CAST(sm.concept_id AS STRING) as stratum_1,
-'2' as stratum_2,
-  'Survey' as stratum_3,
-COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as source_count_value
-from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
-\`${BQ_PROJECT}.${BQ_DATASET}.observation\` ob1
-on p1.person_id = ob1.person_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_question_map\` sq
-On ob1.observation_source_concept_id=sq.question_concept_id
-join \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.survey_module\` sm on sq.survey_concept_id = sm.concept_id
-where (ob1.observation_source_concept_id > 0 and ob1.value_source_concept_id > 0)
-and (extract(year from current_date()) - p1.year_of_birth) >= 18 and (extract(year from current_date()) - p1.year_of_birth) <= 29
-group by sm.concept_id, stratum_2"
-
 
 # Race breakdown of people who took each survey (Row for combinations of each survey and race)
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \

--- a/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
+++ b/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
@@ -306,7 +306,7 @@ CAST(floor((extract(year from condition_start_date) - p1.year_of_birth)/10) AS S
 COUNT(distinct p1.person_id) as count_value,
 COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
 on p1.person_id = co1.person_id where floor((extract(year from condition_start_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from condition_start_date) - p1.year_of_birth)/10) < 9
-and co1.condition_concept_id != co1.condition_source_concept_id
+and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
 group by co1.condition_source_concept_id, stratum_2"
 
 #Get conditions by age decile id 3102 for the 18-29 group labeled as 2
@@ -335,7 +335,7 @@ COUNT(distinct p1.PERSON_ID) as source_count_value from
 on p1.person_id = co1.person_id
 where (extract(year from condition_start_date) - p1.year_of_birth) > 18
 and (extract(year from condition_start_date) - p1.year_of_birth) < 30
-and co1.condition_concept_id != co1.condition_source_concept_id
+and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
 group by co1.condition_source_concept_id,stratum_2"
 
 # Get the 90+ condition age decile counts
@@ -361,7 +361,7 @@ CAST(floor((extract(year from condition_start_date) - p1.year_of_birth)/10) AS S
 COUNT(distinct p1.person_id) as count_value,
 COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
 on p1.person_id = co1.person_id where floor((extract(year from condition_start_date) - p1.year_of_birth)/10) >=9
-and co1.condition_concept_id != co1.condition_source_concept_id
+and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
 group by co1.condition_source_concept_id, stratum_2"
 
 
@@ -388,7 +388,7 @@ CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING)
 COUNT(distinct p1.person_id) as count_value,
 COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
 on p1.person_id = co1.person_id where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.condition_concept_id != co1.condition_source_concept_id
+and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
 group by co1.condition_source_concept_id, stratum_2"
 
 # 90+
@@ -414,7 +414,7 @@ CAST(floor((extract(year from current_date()) - p1.year_of_birth)/10) AS STRING)
 COUNT(distinct p1.person_id) as count_value,
 COUNT(distinct p1.person_id) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
 on p1.person_id = co1.person_id where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.condition_concept_id != co1.condition_source_concept_id
+and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
 group by co1.condition_source_concept_id, stratum_2"
 
 #Get conditions by age decile id 3106 for the 18-29 group labeled as 2
@@ -441,7 +441,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,
 COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co1
 on p1.person_id = co1.person_id
 where (extract(year from current_date()) - p1.year_of_birth) > 18 and (extract(year from current_date()) - p1.year_of_birth) < 30
-and co1.condition_concept_id != co1.condition_source_concept_id
+and co1.condition_source_concept_id not in (select distinct condition_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\`)
 group by co1.condition_source_concept_id,stratum_2"
 
 # No death data now per Kayla. Later when we have more data
@@ -621,7 +621,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,
 COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
 on p1.person_id = co1.person_id
 where (floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) <9)
-and co1.procedure_concept_id != co1.procedure_source_concept_id
+and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
 group by co1.procedure_source_concept_id, stratum_2"
 
 # 600 age 90+
@@ -648,7 +648,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,
 COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
 on p1.person_id = co1.person_id
 where floor((extract(year from co1.procedure_date) - p1.year_of_birth)/10) >=9
-and co1.procedure_concept_id != co1.procedure_source_concept_id
+and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
 group by co1.procedure_source_concept_id, stratum_2"
 
 # 600 age 18-29
@@ -678,6 +678,7 @@ COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DAT
 on p1.person_id = co1.person_id
 where (extract(year from co1.procedure_date) - p1.year_of_birth) >= 18 and
 (extract(year from co1.procedure_date) - p1.year_of_birth) < 30
+and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
 group by co1.procedure_source_concept_id, stratum_2"
 
 # 3106 current age histogram data
@@ -703,7 +704,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,
 COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
 on p1.person_id = co1.person_id
 where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.procedure_concept_id != co1.procedure_source_concept_id
+and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
 group by co1.procedure_source_concept_id, stratum_2"
 
 # 3106 current age histogram data 90+
@@ -729,7 +730,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,
 COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co1
 on p1.person_id = co1.person_id
 where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.procedure_concept_id != co1.procedure_source_concept_id
+and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
 group by co1.procedure_source_concept_id, stratum_2"
 
 # 3106 age 18-29
@@ -758,6 +759,7 @@ COUNT(distinct p1.PERSON_ID) as source_count_value from \`${BQ_PROJECT}.${BQ_DAT
 on p1.person_id = co1.person_id
 where (extract(year from current_date()) - p1.year_of_birth) >= 18 and
 (extract(year from current_date()) - p1.year_of_birth) < 30
+and co1.procedure_source_concept_id not in (select distinct procedure_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\`)
 group by co1.procedure_source_concept_id, stratum_2"
 
 # Drugs
@@ -878,7 +880,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as sour
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
 on p1.person_id = co1.person_id
 where floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) < 9
-and co1.drug_concept_id != co1.drug_source_concept_id
+and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
 group by co1.drug_source_concept_id, stratum_2"
 
 # Drug age 90+
@@ -903,7 +905,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as sour
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
 on p1.person_id = co1.person_id
 where floor((extract(year from co1.drug_exposure_start_date) - p1.year_of_birth)/10) >=9
-and co1.drug_concept_id != co1.drug_source_concept_id
+and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
 group by co1.drug_source_concept_id, stratum_2"
 
 # Drug age decile
@@ -931,7 +933,8 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
 on p1.person_id = co1.person_id
 where (extract(year from co1.drug_exposure_start_date) - p1.year_of_birth) >= 18 and
-(extract(year from co1.drug_exposure_start_date) - p1.year_of_birth) < 30 and co1.drug_concept_id != drug_source_concept_id
+(extract(year from co1.drug_exposure_start_date) - p1.year_of_birth) < 30
+and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
 group by co1.drug_source_concept_id, stratum_2"
 
 # 3106 Drug current age
@@ -956,7 +959,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as sour
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
 on p1.person_id = co1.person_id
 where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.drug_concept_id != co1.drug_source_concept_id
+and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
 group by co1.drug_source_concept_id, stratum_2"
 
 # 3106 Drug current age 90+
@@ -981,7 +984,7 @@ COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as sour
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
 on p1.person_id = co1.person_id
 where floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.drug_concept_id != co1.drug_source_concept_id
+and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
 group by co1.drug_source_concept_id, stratum_2"
 
 # 3106 Drug current age decile 2
@@ -1010,7 +1013,8 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co1
 on p1.person_id = co1.person_id
 where (extract(year from current_date()) - p1.year_of_birth) >= 18 and
-(extract(year from current_date()) - p1.year_of_birth) < 30 and co1.drug_concept_id != drug_source_concept_id
+(extract(year from current_date()) - p1.year_of_birth) < 30
+and co1.drug_source_concept_id not in (select distinct drug_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\`)
 group by co1.drug_source_concept_id, stratum_2"
 
 # 800	(3000) Number of persons with at least one observation occurrence, by observation_concept_id
@@ -1142,7 +1146,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
 on p1.person_id = co1.person_id
 where co1.observation_source_concept_id > 0 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) < 9
-and co1.observation_concept_id != co1.observation_source_concept_id
+and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
 group by co1.observation_source_concept_id, stratum_2
 "
 
@@ -1171,7 +1175,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
 on p1.person_id = co1.person_id
 where co1.observation_source_concept_id > 0 and floor((extract(year from co1.observation_date) - p1.year_of_birth)/10) >=9
-and co1.observation_concept_id != co1.observation_source_concept_id
+and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
 group by co1.observation_source_concept_id, stratum_2
 "
 
@@ -1197,7 +1201,8 @@ COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as sour
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
 on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and (extract(year from co1.observation_date) - p1.year_of_birth) >= 18 and (extract(year from co1.observation_date) - p1.year_of_birth) < 30 and co1.observation_concept_id != co1.observation_source_concept_id
+where co1.observation_concept_id > 0 and (extract(year from co1.observation_date) - p1.year_of_birth) >= 18 and (extract(year from co1.observation_date) - p1.year_of_birth) < 30
+and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
 group by co1.observation_source_concept_id, stratum_2
 "
 
@@ -1226,7 +1231,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
 on p1.person_id = co1.person_id
 where co1.observation_source_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.observation_concept_id != co1.observation_source_concept_id
+and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
 group by co1.observation_source_concept_id, stratum_2
 "
 
@@ -1255,7 +1260,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
 on p1.person_id = co1.person_id
 where co1.observation_source_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.observation_concept_id != co1.observation_source_concept_id
+and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
 group by co1.observation_source_concept_id, stratum_2
 "
 
@@ -1281,7 +1286,8 @@ COUNT(distinct p1.PERSON_ID) as count_value,COUNT(distinct p1.PERSON_ID) as sour
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co1
 on p1.person_id = co1.person_id
-where co1.observation_concept_id > 0 and (extract(year from current_date()) - p1.year_of_birth) >= 18 and (extract(year from current_date()) - p1.year_of_birth) < 30 and co1.observation_concept_id != co1.observation_source_concept_id
+where co1.observation_concept_id > 0 and (extract(year from current_date()) - p1.year_of_birth) >= 18 and (extract(year from current_date()) - p1.year_of_birth) < 30
+and co1.observation_source_concept_id not in (select distinct observation_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.observation\`)
 group by co1.observation_source_concept_id, stratum_2
 "
 
@@ -1396,7 +1402,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
 on p1.person_id = co1.person_id
 where co1.measurement_source_concept_id > 0 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) >=3 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) < 9
-and co1.measurement_concept_id!=co1.measurement_source_concept_id
+and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
 group by co1.measurement_source_concept_id, stratum_2"
 
 # Measurement by age deciles 90+
@@ -1424,7 +1430,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
 on p1.person_id = co1.person_id
 where co1.measurement_source_concept_id > 0 and floor((extract(year from co1.measurement_date) - p1.year_of_birth)/10) >=9
-and co1.measurement_concept_id!=co1.measurement_source_concept_id
+and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
 group by co1.measurement_source_concept_id, stratum_2"
 
 # Measurement  18 - 29 yr old decile 2
@@ -1452,7 +1458,8 @@ COUNT(distinct p1.PERSON_ID) as source_count_value
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
 on p1.person_id = co1.person_id
-where co1.measurement_source_concept_id > 0 and (extract(year from co1.measurement_date) - p1.year_of_birth) >= 18 and (extract(year from co1.measurement_date) - p1.year_of_birth) < 30 and co1.measurement_concept_id!=co1.measurement_source_concept_id
+where co1.measurement_source_concept_id > 0 and (extract(year from co1.measurement_date) - p1.year_of_birth) >= 18 and (extract(year from co1.measurement_date) - p1.year_of_birth) < 30
+and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
 group by co1.measurement_source_concept_id, stratum_2
 "
 
@@ -1481,7 +1488,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
 on p1.person_id = co1.person_id
 where co1.measurement_source_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=3 and floor((extract(year from current_date()) - p1.year_of_birth)/10) < 9
-and co1.measurement_concept_id!=co1.measurement_source_concept_id
+and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
 group by co1.measurement_source_concept_id, stratum_2"
 
 # 3106 Measurement by current age deciles 90+
@@ -1509,7 +1516,7 @@ from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
 on p1.person_id = co1.person_id
 where co1.measurement_source_concept_id > 0 and floor((extract(year from current_date()) - p1.year_of_birth)/10) >=9
-and co1.measurement_concept_id!=co1.measurement_source_concept_id
+and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
 group by co1.measurement_source_concept_id, stratum_2"
 
 # 3106 Measurement  current age histogram 18 - 29 yr old decile 2
@@ -1536,7 +1543,8 @@ COUNT(distinct p1.PERSON_ID) as source_count_value
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p1 inner join
 \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co1
 on p1.person_id = co1.person_id
-where co1.measurement_source_concept_id > 0 and (extract(year from current_date()) - p1.year_of_birth) >= 18 and (extract(year from current_date()) - p1.year_of_birth) < 30 and co1.measurement_concept_id!=co1.measurement_source_concept_id
+where co1.measurement_source_concept_id > 0 and (extract(year from current_date()) - p1.year_of_birth) >= 18 and (extract(year from current_date()) - p1.year_of_birth) < 30
+and co1.measurement_source_concept_id not in (select distinct measurement_concept_id from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\`)
 group by co1.measurement_source_concept_id, stratum_2
 "
 

--- a/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
+++ b/public-api/db-cdr/generate-cdr/run-achilles-queries.sh
@@ -96,12 +96,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "insert into \`${WORKBENCH_PROJECT}.${WORKBENCH_DATASET}.achilles_results\` (id, analysis_id, stratum_1, count_value,source_count_value)
 with person_age as
 (select person_id,
-case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
-when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\`
 group by person_id,age
 )
@@ -282,12 +277,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
  (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with condition_age as
 (select condition_occurrence_id,
-case when extract(month from condition_start_date) < (month_of_birth) and extract(day from condition_start_date) < (day_of_birth) then
-(DATE_DIFF(condition_start_date, extract(date from birth_datetime), year) -1)
-when extract(month from condition_start_date) > (month_of_birth) and extract(day from condition_start_date) > (day_of_birth) then
-(DATE_DIFF(condition_start_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(condition_start_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(condition_start_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.condition_occurrence\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by condition_occurrence_id,age
 ),
@@ -328,12 +318,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
-when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -529,12 +514,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
 with procedure_age as
 (select procedure_occurrence_id,
-case when extract(month from procedure_date) < (month_of_birth) and extract(day from procedure_date) < (day_of_birth) then
-(DATE_DIFF(procedure_date, extract(date from birth_datetime), year) -1)
-when extract(month from procedure_date) > (month_of_birth) and extract(day from procedure_date) > (day_of_birth) then
-(DATE_DIFF(procedure_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(procedure_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(procedure_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.procedure_occurrence\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by procedure_occurrence_id,age
 ),
@@ -576,12 +556,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value,source_count_value)
 with current_person_age as
 (select person_id,
-case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
-when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -720,12 +695,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with drug_age as
 (select drug_exposure_id,
-case when extract(month from drug_exposure_start_date) < (month_of_birth) and extract(day from drug_exposure_start_date) < (day_of_birth) then
-(DATE_DIFF(drug_exposure_start_date, extract(date from birth_datetime), year) -1)
-when extract(month from drug_exposure_start_date) > (month_of_birth) and extract(day from drug_exposure_start_date) > (day_of_birth) then
-(DATE_DIFF(drug_exposure_start_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(drug_exposure_start_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(drug_exposure_start_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.drug_exposure\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by drug_exposure_id,age
 ),
@@ -767,12 +737,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
-when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -919,12 +884,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
 with ob_age as
 (select observation_id,
-case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
-when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -966,12 +926,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2,stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
-when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -1100,12 +1055,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with m_age as
 (select measurement_id,
-case when extract(month from measurement_date) < (month_of_birth) and extract(day from measurement_date) < (day_of_birth) then
-(DATE_DIFF(measurement_date, extract(date from birth_datetime), year) -1)
-when extract(month from measurement_date) > (month_of_birth) and extract(day from measurement_date) > (day_of_birth) then
-(DATE_DIFF(measurement_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(measurement_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(measurement_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.measurement\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by measurement_id,age
 ),
@@ -1147,12 +1097,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id, analysis_id, stratum_1, stratum_2, stratum_3, count_value, source_count_value)
 with current_person_age as
 (select person_id,
-case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
-when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),
@@ -1468,12 +1413,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
-when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1506,12 +1446,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
-when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1543,12 +1478,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
-when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1579,12 +1509,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
-when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1858,12 +1783,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 with survey_age as
 (
 select observation_id,
-case when extract(month from observation_date) < (month_of_birth) and extract(day from observation_date) < (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) -1)
-when extract(month from observation_date) > (month_of_birth) and extract(day from observation_date) > (day_of_birth) then
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(observation_date, extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(observation_datetime, birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.observation\` co join \`${BQ_PROJECT}.${BQ_DATASET}.person\` p on p.person_id=co.person_id
 group by observation_id,age
 ),
@@ -1895,12 +1815,7 @@ bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 (id,analysis_id,stratum_1,stratum_2,stratum_3,count_value,source_count_value)
 with current_person_age as
 (select person_id,
-case when extract(month from current_date()) < (month_of_birth) and extract(day from current_date()) < (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) -1)
-when extract(month from current_date()) > (month_of_birth) and extract(day from current_date()) > (day_of_birth) then
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year) +1)
-else
-(DATE_DIFF(current_date(), extract(date from birth_datetime), year)) end as age
+ceil(TIMESTAMP_DIFF(current_timestamp(), birth_datetime, DAY)/365) as age
 from \`${BQ_PROJECT}.${BQ_DATASET}.person\` p
 group by person_id,age
 ),


### PR DESCRIPTION
1. Updating the query to not count concept twice when it is both source and non-source.
2. Updating the update query that copies the counts from criteria (rolled up counts for snomed conditions and procedures).