### PR TITLE
[risk=no] prefix event category to differentiate from rh events

### DIFF
--- a/public-ui/src/app/utils/db-config.service.ts
+++ b/public-ui/src/app/utils/db-config.service.ts
@@ -330,7 +330,7 @@ export class DbConfigService {
                             eventLabel: string, searchTerm: string, tooltipAction: string) {
     window['dataLayer'].push({
       'event': eventName,
-      'category': eventCategory,
+      'category': 'Data Browser ' + eventCategory,
       'action': eventAction,
       'label': eventLabel,
       'landingSearchTerm': searchTerm,


### PR DESCRIPTION
1. Prefix databrowser event category names to differentiate from research hub events.