### PR TITLE
[DB-612] [risk=no] deal with null pointer exception on search concepts api call

### DIFF
--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -566,10 +566,13 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             response.setMatchType(MatchType.NAME);
         }
 
-        List<Concept> conceptList = new ArrayList(concepts.getContent());
+        List<Concept> conceptList = new ArrayList<>();
 
-        if(response.getStandardConcepts() != null) {
-            conceptList = conceptList.stream().filter(c -> Long.valueOf(c.getConceptId()) != Long.valueOf(response.getSourceOfStandardConcepts())).collect(Collectors.toList());
+        if (concepts != null) {
+            conceptList = new ArrayList(concepts.getContent());
+            if(response.getStandardConcepts() != null) {
+                conceptList = conceptList.stream().filter(c -> Long.valueOf(c.getConceptId()) != Long.valueOf(response.getSourceOfStandardConcepts())).collect(Collectors.toList());
+            }
         }
 
         if(searchConceptsRequest.getDomain() != null && searchConceptsRequest.getDomain().equals(Domain.DRUG) && !searchConceptsRequest.getQuery().isEmpty()) {


### PR DESCRIPTION
1. Trying to fetch content on empty concepts object was causing null pointer exception. Fixing that by adding a check in there.