### PR TITLE
[risk=no] changing data structure from tree set to array list

### DIFF
--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -1151,9 +1151,9 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             }
         } else {
 
-            ArrayList<AchillesResult> maleResults = new ArrayList<AchillesResult>();
-            ArrayList<AchillesResult> femaleResults = new ArrayList<AchillesResult>();
-            ArrayList<AchillesResult> otherResults = new ArrayList<AchillesResult>();
+            List<AchillesResult> maleResults = new ArrayList<>();
+            List<AchillesResult> femaleResults = new ArrayList<>();
+            List<AchillesResult> otherResults = new ArrayList<>();
 
             for(AchillesResult ar: aa.getResults()){
                 String analysisStratumName=ar.getAnalysisStratumName();

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -1151,9 +1151,9 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             }
         } else {
 
-            TreeSet<AchillesResult> maleResults = new TreeSet<AchillesResult>();
-            TreeSet<AchillesResult> femaleResults = new TreeSet<AchillesResult>();
-            TreeSet<AchillesResult> otherResults = new TreeSet<AchillesResult>();
+            ArrayList<AchillesResult> maleResults = new ArrayList<AchillesResult>();
+            ArrayList<AchillesResult> femaleResults = new ArrayList<AchillesResult>();
+            ArrayList<AchillesResult> otherResults = new ArrayList<AchillesResult>();
 
             for(AchillesResult ar: aa.getResults()){
                 String analysisStratumName=ar.getAnalysisStratumName();


### PR DESCRIPTION
1. Method that adds missing bins to measurement concept results throws an error and many measurements do not show up in prod.
2. This was because tree set needs some sort of comparator which achilles result class do not have.
3. Using array list instead of tree set for now.