### PR TITLE
[DB-626] [risk=low] Reducing load time by creating index on concept counts

### DIFF
--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptDao.java
@@ -75,7 +75,7 @@ public interface ConceptDao extends CrudRepository<Concept, Long> {
             "and c.is_selectable = 1 " +
             "and match(c.name, c.code) against(?1 in boolean mode) > 0 " +
             "order by c.name asc) " +
-            "and c1.concept_class_id = 'Ingredient' and (c1.count_value > 0)) ", nativeQuery = true)
+            "and c1.concept_class_id = 'Ingredient' and (c1.has_counts > 0)) ", nativeQuery = true)
     List<Concept> findDrugIngredientsByBrand(String query);
 
     @Query(value = "select distinct c1.* from concept_relationship cr " +
@@ -87,6 +87,6 @@ public interface ConceptDao extends CrudRepository<Concept, Long> {
             "and c.is_selectable = 1 " +
             "and match(c.name, c.code) against(?1 in boolean mode) > 0 " +
             "order by c.name asc) " +
-            "and c1.concept_class_id = 'Ingredient') and cr.concept_id_2 not in (?2) and (c1.count_value > 0)", nativeQuery = true)
+            "and c1.concept_class_id = 'Ingredient') and cr.concept_id_2 not in (?2) and (c1.has_counts > 0)", nativeQuery = true)
     List<Concept> findDrugIngredientsByBrandNotInConceptIds(String query, List<Long> conceptIds);
 }

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
@@ -75,7 +75,7 @@ public class ConceptService {
         }
         String[] keywords = query.split("[,+\\s+]");
         List<String> temp = new ArrayList<>();
-        for (String key: keywords) {
+        for (String key : keywords) {
             String tempKey;
             // This is to exact match concept codes like 100.0, 507.01. Without this mysql was matching 100*, 507*.
             if (key.contains(".")) {
@@ -89,8 +89,7 @@ public class ConceptService {
                     temp.add(tempKey);
                 } else if (tempKey.contains("*") && tempKey.length() > 1) {
                     temp.add(toAdd);
-                }
-                else {
+                } else {
                     if (key.length() < 3) {
                         temp.add(key);
                     } else {
@@ -121,23 +120,18 @@ public class ConceptService {
     public static final String STANDARD_CONCEPT_CODE = "S";
     public static final String CLASSIFICATION_CONCEPT_CODE = "C";
 
-    public Slice<Concept> searchConcepts(String query, StandardConceptFilter standardConceptFilter, List<String> vocabularyIds, List<String> domainIds, int limit, int minCount) {
+    public Slice<Concept> searchConcepts(String query, StandardConceptFilter standardConceptFilter, List<String> vocabularyIds, String domainId, int limit, int minCount) {
 
 
         Specification<Concept> conceptSpecification =
                 (root, criteriaQuery, criteriaBuilder) -> {
                     List<Predicate> predicates = new ArrayList<>();
                     List<Predicate> standardConceptPredicates = new ArrayList<>();
-                    standardConceptPredicates.add(criteriaBuilder.equal(root.get("standardConcept"),
-                            criteriaBuilder.literal(STANDARD_CONCEPT_CODE)));
-                    standardConceptPredicates.add(criteriaBuilder.equal(root.get("standardConcept"),
-                            criteriaBuilder.literal(CLASSIFICATION_CONCEPT_CODE)));
+                    standardConceptPredicates.add(root.get("standardConcept").in(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE));
 
                     List<Predicate> nonStandardConceptPredicates = new ArrayList<>();
-                    nonStandardConceptPredicates.add(criteriaBuilder.notEqual(root.get("standardConcept"),
-                            criteriaBuilder.literal(STANDARD_CONCEPT_CODE)));
-                    nonStandardConceptPredicates.add(criteriaBuilder.notEqual(root.get("standardConcept"),
-                            criteriaBuilder.literal(CLASSIFICATION_CONCEPT_CODE)));
+                    nonStandardConceptPredicates.add(criteriaBuilder.not
+                            (root.get("standardConcept").in(STANDARD_CONCEPT_CODE, CLASSIFICATION_CONCEPT_CODE)));
 
                     final String keyword = modifyMultipleMatchKeyword(query, SearchType.CONCEPT_SEARCH);
 
@@ -160,7 +154,7 @@ public class ConceptService {
                                 ));
 
                     } else if (standardConceptFilter.equals(StandardConceptFilter.STANDARD_OR_CODE_ID_MATCH)) {
-                        if(keyword != null){
+                        if (keyword != null) {
                             List<Predicate> standardOrCodeOrIdMatch = new ArrayList<>();
                             standardOrCodeOrIdMatch.add(criteriaBuilder.equal(root.get("conceptCode"),
                                     criteriaBuilder.literal(query)));
@@ -184,18 +178,10 @@ public class ConceptService {
                     if (vocabularyIds != null) {
                         predicates.add(root.get("vocabularyId").in(vocabularyIds));
                     }
-                    if (domainIds != null) {
-                        predicates.add(root.get("domainId").in(domainIds));
+                    if (domainId != null) {
+                        predicates.add(criteriaBuilder.equal(root.get("domainId"), criteriaBuilder.literal(domainId)));
                     }
-
-                    if (minCount == 1) {
-                        List<Predicate> countPredicates = new ArrayList<>();
-                        countPredicates.add(criteriaBuilder.greaterThan(root.get("countValue"), 0));
-                        countPredicates.add(criteriaBuilder.greaterThan(root.get("sourceCountValue"), 0));
-
-                        predicates.add(criteriaBuilder.or(
-                                countPredicates.toArray(new Predicate[0])));
-                    }
+                    predicates.add(criteriaBuilder.greaterThan(root.get("hasCounts"), 0));
 
                     predicates.add(criteriaBuilder.greaterThan(root.get("canSelect"), 0));
 

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/ConceptService.java
@@ -181,8 +181,9 @@ public class ConceptService {
                     if (domainId != null) {
                         predicates.add(criteriaBuilder.equal(root.get("domainId"), criteriaBuilder.literal(domainId)));
                     }
-                    predicates.add(criteriaBuilder.greaterThan(root.get("hasCounts"), 0));
-
+                    if (minCount == 1) {
+                        predicates.add(criteriaBuilder.greaterThan(root.get("hasCounts"), 0));
+                    }
                     predicates.add(criteriaBuilder.greaterThan(root.get("canSelect"), 0));
 
                     criteriaQuery.distinct(true);

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/dao/DomainInfoDao.java
@@ -27,7 +27,7 @@ public interface DomainInfoDao extends CrudRepository<DomainInfo, Long> {
       "  select c1.domain_id, count(*) as count " +
       "  from (" +
       "    (select domain_id, concept_id from concept " +
-      "     where (count_value > 0 or source_count_value > 0) and " +
+      "     where has_counts > 0 and " +
       "       match(concept_name, concept_code, vocabulary_id, synonyms) against (?1 in boolean mode) > 0 and " +
       "       standard_concept IN ('S', 'C') and can_select=1) " +
       // An OR of these different conditions would be easier, but MySQL will not leverage the full

--- a/common-api/src/main/java/org/pmiops/workbench/cdr/model/Concept.java
+++ b/common-api/src/main/java/org/pmiops/workbench/cdr/model/Concept.java
@@ -33,6 +33,7 @@ public class Concept {
     private List<String> synonyms = new ArrayList<>();
     private String synonymsStr;
     private int canSelect;
+    private int hasCounts;
 
     public Concept() {}
 
@@ -233,6 +234,20 @@ public class Concept {
         return this;
     }
 
+    @Column(name = "has_counts")
+    public int getHasCounts() {
+        return hasCounts;
+    }
+
+    public void setHasCounts(int hasCounts) {
+        this.hasCounts = hasCounts;
+    }
+
+    public Concept hasCounts(int hasCounts) {
+        this.hasCounts = hasCounts;
+        return this;
+    }
+
     @Transient
     public List<String> getSynonyms() {
         return synonyms;
@@ -265,7 +280,7 @@ public class Concept {
 
     @Override
     public int hashCode() {
-        return Objects.hash(conceptId, conceptName, standardConcept, conceptCode, conceptClassId, vocabularyId, domainId, countValue, sourceCountValue,prevalence, canSelect);
+        return Objects.hash(conceptId, conceptName, standardConcept, conceptCode, conceptClassId, vocabularyId, domainId, countValue, sourceCountValue,prevalence, canSelect, hasCounts);
     }
 
     @Override

--- a/public-api/config/cdr_versions_test.json
+++ b/public-api/config/cdr_versions_test.json
@@ -10,6 +10,6 @@
     "releaseNumber": 1,
     "numParticipants": 946237,
     "cdrDbName": "cdr20181023",
-    "publicDbName": "synth_p_2019q1_13"
+    "publicDbName": "synth_p_2019q1_14"
   }
 ]

--- a/public-api/db-cdr/changelog-schema/db.changelog-29.xml
+++ b/public-api/db-cdr/changelog-schema/db.changelog-29.xml
@@ -8,7 +8,6 @@
   <changeSet author="srushtigangireddy" runAlways="true" onValidationFail="MARK_RAN" id="changelog-29">
     <validCheckSum>ANY</validCheckSum>
     <addColumn tableName="concept">
-      <!-- Contains the tree path of the concept -->
       <column name="has_counts" type="BOOL">
         <constraints nullable="true"/>
       </column>

--- a/public-api/db-cdr/changelog-schema/db.changelog-29.xml
+++ b/public-api/db-cdr/changelog-schema/db.changelog-29.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+  <changeSet author="srushtigangireddy" runAlways="true" onValidationFail="MARK_RAN" id="changelog-29">
+    <validCheckSum>ANY</validCheckSum>
+    <addColumn tableName="concept">
+      <!-- Contains the tree path of the concept -->
+      <column name="has_counts" type="BOOL">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+    <sql dbms="mysql">
+      ALTER TABLE concept
+      ADD INDEX domain_count_index
+      (domain_id,has_counts);
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/public-api/db-cdr/changelog-schema/db.changelog-master.xml
+++ b/public-api/db-cdr/changelog-schema/db.changelog-master.xml
@@ -34,4 +34,5 @@
   <include file="changelog-schema/db.changelog-26.xml"/>
   <include file="changelog-schema/db.changelog-27.xml"/>
   <include file="changelog-schema/db.changelog-28.xml"/>
+  <include file="changelog-schema/db.changelog-29.xml"/>
 </databaseChangeLog>

--- a/public-api/db-cdr/generate-cdr/bq-schemas/concept.json
+++ b/public-api/db-cdr/generate-cdr/bq-schemas/concept.json
@@ -58,5 +58,10 @@
 		"mode": "NULLABLE",
 		"name": "can_select",
 		"type": "INTEGER"
+	},
+	{
+		"mode": "NULLABLE",
+		"name": "has_counts",
+		"type": "INTEGER"
 	}
 ]

--- a/public-api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/public-api/db-cdr/generate-cdr/make-bq-data.sh
@@ -453,11 +453,12 @@ echo "Inserting concept table data ... "
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "INSERT INTO \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\`
 (concept_id, concept_name, domain_id, vocabulary_id, concept_class_id, standard_concept,
-concept_code, count_value, prevalence, source_count_value, synonyms, can_select)
+concept_code, count_value, prevalence, source_count_value, synonyms, can_select, has_counts)
 select c.concept_id, c.concept_name, c.domain_id, c.vocabulary_id, c.concept_class_id, c.standard_concept, c.concept_code,
 0 as count_value , 0.0 as prevalence, 0 as source_count_value,concat(cast(c.concept_id as string),'|',string_agg(replace(cs.concept_synonym_name,'|','||'),'|')) as synonyms,
 (case when (c.concept_id in (select distinct concept_id from \`$OUTPUT_PROJECT.$OUTPUT_DATASET.filter_conditions\`)
-and (select flag from \`$OUTPUT_PROJECT.$OUTPUT_DATASET.filter_conditions\` where concept_id = c.concept_id)=0) then 0 else 1 end) as can_select
+and (select flag from \`$OUTPUT_PROJECT.$OUTPUT_DATASET.filter_conditions\` where concept_id = c.concept_id)=0) then 0 else 1 end) as can_select,
+0 as has_select
 from \`${BQ_PROJECT}.${BQ_DATASET}.concept\` c join \`${BQ_PROJECT}.${BQ_DATASET}.concept_synonym\` cs on c.concept_id=cs.concept_id
 group by c.concept_id,c.concept_name,c.domain_id,c.vocabulary_id,c.concept_class_id, c.standard_concept, c.concept_code"
 
@@ -632,6 +633,16 @@ set c.count_value=sub_cr.cnt
 from (select analysis_id, concept_id, stratum_1 as stratum, domain, max(count_value) as cnt from \`$OUTPUT_PROJECT.$OUTPUT_DATASET.criteria_stratum\` cr
 group by analysis_id, concept_id, stratum, domain) as sub_cr
 where cast(sub_cr.concept_id as string)=c.stratum_1 and c.analysis_id=sub_cr.analysis_id and c.stratum_2=cast(sub_cr.stratum as string) and c.stratum_3=sub_cr.domain"
+
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"Update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
+set has_counts = 1
+where (c.count_value > 0 or c.source_count_value > 0)"
+
+bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
+"Update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
+set has_counts = 0
+where (c.count_value = 0 and c.source_count_value = 0)"
 
 #######################
 # Drop views created #

--- a/public-api/db-cdr/generate-cdr/make-bq-data.sh
+++ b/public-api/db-cdr/generate-cdr/make-bq-data.sh
@@ -636,13 +636,8 @@ where cast(sub_cr.concept_id as string)=c.stratum_1 and c.analysis_id=sub_cr.ana
 
 bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
 "Update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
-set has_counts = 1
-where (c.count_value > 0 or c.source_count_value > 0)"
-
-bq --quiet --project=$BQ_PROJECT query --nouse_legacy_sql \
-"Update \`$OUTPUT_PROJECT.$OUTPUT_DATASET.concept\` c
-set has_counts = 0
-where (c.count_value = 0 and c.source_count_value = 0)"
+set has_counts = IF(count_value > 0 or source_count_value > 0, 1, 0)
+where concept_id != 0"
 
 #######################
 # Drop views created #

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -534,16 +534,16 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             }
         }
 
-        List<String> domainIds = null;
+        String domainId = null;
         if (searchConceptsRequest.getDomain() != null) {
-            domainIds = ImmutableList.of(CommonStorageEnums.domainToDomainId(searchConceptsRequest.getDomain()));
+            domainId = CommonStorageEnums.domainToDomainId(searchConceptsRequest.getDomain());
         }
 
         ConceptService.StandardConceptFilter convertedConceptFilter = ConceptService.StandardConceptFilter.valueOf(standardConceptFilter.name());
 
         Slice<Concept> concepts = null;
         concepts = conceptService.searchConcepts(searchConceptsRequest.getQuery(), convertedConceptFilter,
-                searchConceptsRequest.getVocabularyIds(), domainIds, maxResults, minCount);
+                searchConceptsRequest.getVocabularyIds(), domainId, maxResults, minCount);
         ConceptListResponse response = new ConceptListResponse();
 
         for(Concept con : concepts.getContent()){

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -160,7 +160,8 @@ public class DataBrowserController implements DataBrowserApiDelegate {
                             .countValue(concept.getCountValue())
                             .sourceCountValue(concept.getSourceCountValue())
                             .prevalence(concept.getPrevalence())
-                            .conceptSynonyms(concept.getSynonyms());
+                            .conceptSynonyms(concept.getSynonyms())
+                            .hasCounts(concept.getHasCounts());
                 }
             };
 

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -160,8 +160,7 @@ public class DataBrowserController implements DataBrowserApiDelegate {
                             .countValue(concept.getCountValue())
                             .sourceCountValue(concept.getSourceCountValue())
                             .prevalence(concept.getPrevalence())
-                            .conceptSynonyms(concept.getSynonyms())
-                            .hasCounts(concept.getHasCounts());
+                            .conceptSynonyms(concept.getSynonyms());
                 }
             };
 

--- a/public-api/src/main/resources/public-api.yaml
+++ b/public-api/src/main/resources/public-api.yaml
@@ -339,6 +339,10 @@ definitions:
         type: "array"
         items:
           type: "string"
+      hasCounts:
+        description: boolean value which determines if this concept has counts or not
+        type: integer
+        format: int32
 
   ConceptListResponse:
     type: object

--- a/public-api/src/main/resources/public-api.yaml
+++ b/public-api/src/main/resources/public-api.yaml
@@ -339,10 +339,6 @@ definitions:
         type: "array"
         items:
           type: "string"
-      hasCounts:
-        description: boolean value which determines if this concept has counts or not
-        type: integer
-        format: int32
 
   ConceptListResponse:
     type: object

--- a/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
+++ b/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
@@ -71,8 +71,7 @@ public class DataBrowserControllerTest {
             .countValue(123L)
             .sourceCountValue(20L)
             .prevalence(0.2F)
-            .conceptSynonyms(new ArrayList<String>())
-            .hasCounts(1);
+            .conceptSynonyms(new ArrayList<String>());
 
     private static final Concept CLIENT_CONCEPT_2 = new Concept()
             .conceptId(456L)
@@ -84,8 +83,7 @@ public class DataBrowserControllerTest {
             .countValue(456L)
             .sourceCountValue(25L)
             .prevalence(0.3F)
-            .conceptSynonyms(new ArrayList<String>())
-            .hasCounts(1);
+            .conceptSynonyms(new ArrayList<String>());
 
     private static final Concept CLIENT_CONCEPT_3 = new Concept()
             .conceptId(789L)
@@ -98,8 +96,7 @@ public class DataBrowserControllerTest {
             .countValue(789L)
             .sourceCountValue(0L)
             .prevalence(0.4F)
-            .conceptSynonyms(new ArrayList<String>())
-            .hasCounts(1);
+            .conceptSynonyms(new ArrayList<String>());
 
     private static final Concept CLIENT_CONCEPT_4 = new Concept()
             .conceptId(1234L)
@@ -112,8 +109,7 @@ public class DataBrowserControllerTest {
             .countValue(1250L)
             .sourceCountValue(99L)
             .prevalence(0.5F)
-            .conceptSynonyms(new ArrayList<String>())
-            .hasCounts(1);
+            .conceptSynonyms(new ArrayList<String>());
 
     private static final Concept CLIENT_CONCEPT_5 = new Concept()
             .conceptId(7890L)
@@ -126,8 +122,7 @@ public class DataBrowserControllerTest {
             .countValue(7890L)
             .sourceCountValue(78L)
             .prevalence(0.9F)
-            .conceptSynonyms(new ArrayList<String>())
-            .hasCounts(1);
+            .conceptSynonyms(new ArrayList<String>());
 
     private static final Concept CLIENT_CONCEPT_6 = new Concept()
             .conceptId(7891L)
@@ -140,8 +135,7 @@ public class DataBrowserControllerTest {
             .countValue(0L)
             .sourceCountValue(20L)
             .prevalence(0.1F)
-            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"))
-            .hasCounts(1);
+            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"));
 
   private static final Concept CLIENT_CONCEPT_7 = new Concept()
             .conceptId(7892L)
@@ -154,8 +148,7 @@ public class DataBrowserControllerTest {
             .countValue(0L)
             .sourceCountValue(0L)
             .prevalence(0.0F)
-            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"))
-            .hasCounts(0);
+            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"));
 
     private static final DomainInfo CLIENT_DOMAIN_1 = new DomainInfo()
             .domain(Domain.CONDITION)
@@ -581,7 +574,11 @@ public class DataBrowserControllerTest {
         String.valueOf(concept.getConceptId()) + '|' +
             Joiner.on("|").join(concept.getConceptSynonyms()));
     result.setCanSelect(1);
-    result.setHasCounts(concept.getHasCounts());
+    if (concept.getConceptId() == 7892) {
+        result.setHasCounts(0);
+    } else {
+        result.setHasCounts(1);
+    }
     return result;
   }
 

--- a/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
+++ b/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
@@ -71,7 +71,8 @@ public class DataBrowserControllerTest {
             .countValue(123L)
             .sourceCountValue(20L)
             .prevalence(0.2F)
-            .conceptSynonyms(new ArrayList<String>());
+            .conceptSynonyms(new ArrayList<String>())
+            .hasCounts(1);
 
     private static final Concept CLIENT_CONCEPT_2 = new Concept()
             .conceptId(456L)
@@ -83,7 +84,8 @@ public class DataBrowserControllerTest {
             .countValue(456L)
             .sourceCountValue(25L)
             .prevalence(0.3F)
-            .conceptSynonyms(new ArrayList<String>());
+            .conceptSynonyms(new ArrayList<String>())
+            .hasCounts(1);
 
     private static final Concept CLIENT_CONCEPT_3 = new Concept()
             .conceptId(789L)
@@ -96,7 +98,8 @@ public class DataBrowserControllerTest {
             .countValue(789L)
             .sourceCountValue(0L)
             .prevalence(0.4F)
-            .conceptSynonyms(new ArrayList<String>());
+            .conceptSynonyms(new ArrayList<String>())
+            .hasCounts(1);
 
     private static final Concept CLIENT_CONCEPT_4 = new Concept()
             .conceptId(1234L)
@@ -109,7 +112,8 @@ public class DataBrowserControllerTest {
             .countValue(1250L)
             .sourceCountValue(99L)
             .prevalence(0.5F)
-            .conceptSynonyms(new ArrayList<String>());
+            .conceptSynonyms(new ArrayList<String>())
+            .hasCounts(1);
 
     private static final Concept CLIENT_CONCEPT_5 = new Concept()
             .conceptId(7890L)
@@ -122,7 +126,8 @@ public class DataBrowserControllerTest {
             .countValue(7890L)
             .sourceCountValue(78L)
             .prevalence(0.9F)
-            .conceptSynonyms(new ArrayList<String>());
+            .conceptSynonyms(new ArrayList<String>())
+            .hasCounts(1);
 
     private static final Concept CLIENT_CONCEPT_6 = new Concept()
             .conceptId(7891L)
@@ -135,7 +140,8 @@ public class DataBrowserControllerTest {
             .countValue(0L)
             .sourceCountValue(20L)
             .prevalence(0.1F)
-            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"));
+            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"))
+            .hasCounts(1);
 
   private static final Concept CLIENT_CONCEPT_7 = new Concept()
             .conceptId(7892L)
@@ -148,7 +154,8 @@ public class DataBrowserControllerTest {
             .countValue(0L)
             .sourceCountValue(0L)
             .prevalence(0.0F)
-            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"));
+            .conceptSynonyms(ImmutableList.of("cstest 1", "cstest 2", "cstest 3"))
+            .hasCounts(0);
 
     private static final DomainInfo CLIENT_DOMAIN_1 = new DomainInfo()
             .domain(Domain.CONDITION)
@@ -574,7 +581,7 @@ public class DataBrowserControllerTest {
         String.valueOf(concept.getConceptId()) + '|' +
             Joiner.on("|").join(concept.getConceptSynonyms()));
     result.setCanSelect(1);
-    result.setHasCounts(1);
+    result.setHasCounts(concept.getHasCounts());
     return result;
   }
 

--- a/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
+++ b/public-api/src/test/java/org/pmiops/workbench/cdr/DataBrowserControllerTest.java
@@ -574,6 +574,7 @@ public class DataBrowserControllerTest {
         String.valueOf(concept.getConceptId()) + '|' +
             Joiner.on("|").join(concept.getConceptSynonyms()));
     result.setCanSelect(1);
+    result.setHasCounts(1);
     return result;
   }
 


### PR DESCRIPTION
1. Reduce the load time (especially of drug exposures) by reducing load time of drug concepts.
2. Index on count column would help anyways instead of having count > 0 or source count > 0 condition always.
3. Changed domain id param to string instead of list, since it is always passing only one domain.