### PR TITLE
[DB-595] [risk=no] Overflow tooltips when long

### DIFF
--- a/public-ui/src/styles.css
+++ b/public-ui/src/styles.css
@@ -541,6 +541,10 @@ a a:link a:visited {
   margin:0;
 }
 
+.highcharts-container{
+  overflow:visible !important;
+}
+
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
   /* IE10+ CSS styles go here */
   .headwrap {


### PR DESCRIPTION
1. Overflow tooltips when the length of labels is long.