### PR TITLE
[risk=no] [DB-682] fix the second level survey sub question's did not answer count

### DIFF
--- a/public-ui/src/app/views/survey-view/survey-view.component.ts
+++ b/public-ui/src/app/views/survey-view/survey-view.component.ts
@@ -169,7 +169,7 @@ export class SurveyViewComponent implements OnInit, OnDestroy {
                       });
                       question.countAnalysis.surveyQuestionResults.push(
                         this.addDidNotAnswerResult(
-                          question.countAnalysis.surveyQuestionResults, subQuestion.countValue)
+                          question.countAnalysis.surveyQuestionResults, subResult.countValue)
                       );
                       for (const subResult2 of question.countAnalysis.surveyQuestionResults.
                         filter(r => r.subQuestions === null)) {


### PR DESCRIPTION
1. Use the count of answer from which the second level sub question branched to calculate did not answer count instead of count of question.