### PR TITLE
[risk=no] [DB-630] increasing min idle instances

### DIFF
--- a/deploy/libproject/deploy.rb
+++ b/deploy/libproject/deploy.rb
@@ -302,6 +302,7 @@ def deploy(cmd_name, args)
   err_str, value = Open3.capture2e(*(%W{../public-api/project.rb integration --env #{op.opts.project}}))
   maybe_log_jira.call "'#{op.opts.project}': API integration tests #{value.success? ? 'passed' : 'FAILED'}"
   unless value.success?
+    common.run_inline %W{../public-api/project.rb integration --env #{op.opts.project}}
     common.error(err_str)
     exit value.exitstatus
   end

--- a/public-api/libproject/devstart.rb
+++ b/public-api/libproject/devstart.rb
@@ -24,7 +24,7 @@ SERVICES = %W{servicemanagement.googleapis.com storage-component.googleapis.com 
               clouderrorreporting.googleapis.com bigquery-json.googleapis.com}
 DRY_RUN_CMD = %W{echo [DRY_RUN]}
 TEST_GAE_VARS = {
-  "GAE_MIN_INSTANCES" => "0",
+  "GAE_MIN_INSTANCES" => "1",
   "GAE_MAX_INSTANCES" => "10"
 }
 


### PR DESCRIPTION
1. Integration tests fail on stable environment.
2. Increasing min instances to fix that as in prod.