### PR TITLE
[risk=no] [DB-814] save drug results and display them over pages

### DIFF
--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/DataBrowserController.java
@@ -604,7 +604,8 @@ public class DataBrowserController implements DataBrowserApiDelegate {
             }
         }
 
-        if(searchConceptsRequest.getDomain() != null && searchConceptsRequest.getDomain().equals(Domain.DRUG) && searchConceptsRequest.getQuery() != null && !searchConceptsRequest.getQuery().isEmpty()) {
+        if(searchConceptsRequest.getDomain() != null && searchConceptsRequest.getDomain().equals(Domain.DRUG) && searchConceptsRequest.getQuery() != null && !searchConceptsRequest.getQuery().isEmpty()
+                && searchConceptsRequest.getPageNumber() == 0) {
             List<Concept> drugMatchedConcepts = new ArrayList<>();
             if (conceptList.size() > 0) {
                 drugMatchedConcepts = conceptDao.findDrugIngredientsByBrandNotInConceptIds(searchConceptsRequest.getQuery(), conceptList.stream().map(Concept::getConceptId).collect(Collectors.toList()));

--- a/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.html
+++ b/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.html
@@ -39,7 +39,7 @@
                   </ng-container>
                   <ng-template #show_pages>
                     <h5 id="domain-name" class="primary-display">
-                      Showing top {{((currentPage * searchRequest.maxResults) - items.length)+1}} -
+                      Showing top {{((currentPage-1) * searchRequest.maxResults)+1}} -
                       {{items.length + (searchRequest.pageNumber * searchRequest.maxResults)}} of {{totalResults}}
                     </h5>
                   </ng-template>
@@ -157,7 +157,7 @@
                     <div class="body-lead info-text tbl-d first">
                       <div class="code-tooltip">
                           <span *ngIf="totalResults > searchRequest.maxResults" class="item-index">
-                            {{i+((currentPage * searchRequest.maxResults) - items.length)+1}}.
+                            {{i+((currentPage-1) * searchRequest.maxResults)+1}}.
                           </span>
                         <span *ngIf="totalResults <= searchRequest.maxResults" class="item-index">{{i+1}}.</span>
                         <app-highlight-search [text]="r.conceptName" [searchTerm]="prevSearchText">

--- a/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
+++ b/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
@@ -36,6 +36,7 @@ export class EhrViewComponent implements OnInit, OnDestroy {
   prevSearchText = '';
   searchResult: ConceptListResponse;
   items: any[] = [];
+  fullResultItemsList: any[] = [];
   standardConcepts: any[] = [];
   standardConceptIds: number[] = [];
   graphButtons: any = [];
@@ -250,6 +251,15 @@ export class EhrViewComponent implements OnInit, OnDestroy {
     this.searchResult.items = this.searchResult.items.filter(
       x => this.dbc.TO_SUPPRESS_PMS.indexOf(x.conceptId) === -1);
     this.items = this.searchResult.items;
+    if (this.domainId === 'drug' && this.items.length > this.searchRequest.maxResults) {
+      this.fullResultItemsList = this.items;
+      this.items = this.items.slice(((this.currentPage-1)*this.searchRequest.maxResults),
+        (((this.currentPage-1))*this.searchRequest.maxResults) + this.searchRequest.maxResults);
+    }
+    if (this.domainId === 'drug' && this.currentPage > 1) {
+      this.items = this.fullResultItemsList.slice(((this.currentPage-1)*this.searchRequest.maxResults),
+        (((this.currentPage-1))*this.searchRequest.maxResults) + this.searchRequest.maxResults);
+    }
     this.items = this.items.sort((a, b) => {
       if (a.countValue > b.countValue) {
         return -1;

--- a/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
+++ b/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
@@ -253,12 +253,13 @@ export class EhrViewComponent implements OnInit, OnDestroy {
     this.items = this.searchResult.items;
     if (this.domainId === 'drug' && this.items.length > this.searchRequest.maxResults) {
       this.fullResultItemsList = this.items;
-      this.items = this.items.slice(((this.currentPage-1)*this.searchRequest.maxResults),
-        (((this.currentPage-1))*this.searchRequest.maxResults) + this.searchRequest.maxResults);
+      this.items = this.items.slice(((this.currentPage - 1) * this.searchRequest.maxResults),
+        (((this.currentPage - 1)) * this.searchRequest.maxResults) + this.searchRequest.maxResults);
     }
     if (this.domainId === 'drug' && this.currentPage > 1) {
-      this.items = this.fullResultItemsList.slice(((this.currentPage-1)*this.searchRequest.maxResults),
-        (((this.currentPage-1))*this.searchRequest.maxResults) + this.searchRequest.maxResults);
+      this.items = this.fullResultItemsList
+        .slice(((this.currentPage - 1) * this.searchRequest.maxResults),
+        (((this.currentPage - 1)) * this.searchRequest.maxResults) + this.searchRequest.maxResults);
     }
     this.items = this.items.sort((a, b) => {
       if (a.countValue > b.countValue) {


### PR DESCRIPTION
1. Drug results are extra and are messing up with pagination.
2. Do not fetch drug results in subsequent page. (Because we would already have them with 1st page search).
3. Save them and display over pages.
