### PR TITLE
[risk=no] Downgrade from 10 -> 1 idle task

### DIFF
--- a/public-api/libproject/devstart.rb
+++ b/public-api/libproject/devstart.rb
@@ -56,7 +56,7 @@ ENVIRONMENTS = {
     :cdr_versions_json => "cdr_versions_prod.json",
     :api_base_path => "https://public.api.researchallofus.org",
     :gae_vars => {
-      "GAE_MIN_IDLE_INSTANCES" => "10",
+      "GAE_MIN_IDLE_INSTANCES" => "1",
       "GAE_MAX_INSTANCES" => "64"
     }
   }


### PR DESCRIPTION
From historical data, this should be sufficient to support our current load. GAE will autoscale if needed under heavier load. We should keep a watch for any increased error rates (timeouts) as a result of this change.

<!--
Replace this this template with your PR description.
Please remember to keep in mind the security levels outlined in [CONTRIBUTING.md](CONTRIBUTING.md) and to 
include a risk tag of the form `[risk=no|low|moderate|severe]` in the PR title

* **no**: None 
* **low**: Low chance of potential impact to, or exposure of patient data
* **moderate**: Moderate chance of potential impact to, or exposure of patient data
* **severe**: Severe chance of potential impact to, or exposure of patient data

Please also:

* Get thumbs from reviewer(s)
* Verify all tests go green, including CI tests
-->
