### PR TITLE
[risk=no] Do not load concept graph twice

### DIFF
--- a/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
+++ b/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
@@ -134,7 +134,7 @@ export class EhrViewComponent implements OnInit, OnDestroy {
         this.prevSearchText = localStorage.getItem('searchText');
       }
     }
-    this.searchText.setValue(this.prevSearchText);
+    //this.searchText.setValue(this.prevSearchText);
     const domainObj = JSON.parse(localStorage.getItem('ehrDomain'));
     // if no domainObj or if the domain in the obj doesn't match the route
     if (!domainObj || domainObj.domain !== this.domainId) {

--- a/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
+++ b/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
@@ -134,7 +134,7 @@ export class EhrViewComponent implements OnInit, OnDestroy {
         this.prevSearchText = localStorage.getItem('searchText');
       }
     }
-    //this.searchText.setValue(this.prevSearchText);
+    // this.searchText.setValue(this.prevSearchText);
     const domainObj = JSON.parse(localStorage.getItem('ehrDomain'));
     // if no domainObj or if the domain in the obj doesn't match the route
     if (!domainObj || domainObj.domain !== this.domainId) {

--- a/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
+++ b/public-ui/src/app/data-browser/views/ehr-view/ehr-view.component.ts
@@ -134,7 +134,6 @@ export class EhrViewComponent implements OnInit, OnDestroy {
         this.prevSearchText = localStorage.getItem('searchText');
       }
     }
-    // this.searchText.setValue(this.prevSearchText);
     const domainObj = JSON.parse(localStorage.getItem('ehrDomain'));
     // if no domainObj or if the domain in the obj doesn't match the route
     if (!domainObj || domainObj.domain !== this.domainId) {


### PR DESCRIPTION
1. Setting search text value in loadPage function is triggering the search text value change and api request fire which is causing reload.