### PR TITLE
[risk=no][DB-849]adding loadSourceTree to expandRow 

### DIFF
--- a/public-ui/src/app/data-browser/db-table/db-table.component.ts
+++ b/public-ui/src/app/data-browser/db-table/db-table.component.ts
@@ -216,6 +216,7 @@ export class DbTableComponent implements OnChanges, OnDestroy {
   }
 
   public expandRow(concept: any, fromChart?: boolean) {
+    this.loadSourceTree(concept);
     this.expanded = true;
     // analytics
     this.dbc.triggerEvent('conceptClick', 'Concept', 'Click',


### PR DESCRIPTION
this fixes the issue when a user clicks the top chart they would get the previous source tree. 