### PR TITLE
[ris=no] Remove cdr pipeline commands from docker

### DIFF
--- a/public-api/db-cdr/generate-cdr/cloudsql-import.sh
+++ b/public-api/db-cdr/generate-cdr/cloudsql-import.sh
@@ -54,6 +54,8 @@ then
   exit 1
 fi
 
+SERVICE_ACCOUNT=$(gcloud config get-value account)
+
 # Function for waiting on import to finish.
 # import_wait($file, $seconds_wait_interval)
 function import_wait () {
@@ -77,10 +79,10 @@ function import_wait () {
 # Function to Grant Access to files for service account and db
 function grant_access_to_files () {
   bucket_path=$1
-  SERVICE_ACCOUNT="${PROJECT}@appspot.gserviceaccount.com"
+  # SERVICE_ACCOUNT="${PROJECT}@appspot.gserviceaccount.com"
 
-  gsutil acl ch -u $SERVICE_ACCOUNT:O $bucket_path 2> /dev/null || true # Don't error if there are no files
-  gcloud auth activate-service-account $SERVICE_ACCOUNT --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+  # gsutil acl ch -u $SERVICE_ACCOUNT:O $bucket_path 2> /dev/null || true # Don't error if there are no files
+  # gcloud auth activate-service-account $SERVICE_ACCOUNT --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
   # Grant access to buckets for service account for cloudsql
   SQL_SERVICE_ACCOUNT=$(gcloud sql instances describe --project $PROJECT \

--- a/public-api/db-cdr/generate-cdr/generate-cloudsql-db.sh
+++ b/public-api/db-cdr/generate-cdr/generate-cloudsql-db.sh
@@ -5,46 +5,19 @@
 # Example usage, you need to provide a bunch of args
 # ./project.rb generate-cloudsql-dbs --cdr-version 20180130 --bucket all-of-us-workbench-private
 
-set -xeuo pipefail
-IFS=$'\n\t'
+set -ex
 
-USAGE="./generate-cdr/generate-cloudsql-db.sh --project <PROJECT> --instance <INSTANCE> --database <cdrYYYYMMDD> \
---bucket <BUCKET>"
+export PROJECT=$1  # project
+export INSTANCE=$2  # database instance
+export DATABASE=$3 # cdr version
+export BUCKET=$4 # bucket in which csvs are present
 
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --project) PROJECT=$2; shift 2;;
-    --instance) INSTANCE=$2; shift 2;;
-    --database) DATABASE=$2; shift 2;;
-    --bucket) BUCKET=$2; shift;;
-    -- ) shift; break ;;
-    * ) break ;;
-  esac
-done
+startDate=$(date)
+echo " Starting generate-cloudsql-db $DATABASE from bucket $BUCKET $startDate"
 
-if [ -z "${PROJECT}" ]
-then
-  echo $USAGE
-  exit 1
-fi
+SERVICE_ACCOUNT=$(gcloud config get-value account)
 
-if [ -z "${INSTANCE}" ]
-then
-  echo $USAGE
-  exit 1
-fi
-
-if [ -z "${DATABASE}" ]
-then
-  echo $USAGE
-  exit 1
-fi
-
-if [ -z "${BUCKET}" ]
-then
-  echo $USAGE
-  exit 1
-fi
+echo "********* Service account active $SERVICE_ACCOUNT **********"
 
 startDate=$(date)
 echo " Starting generate-cloudsql-db $DATABASE from bucket $BUCKET $startDate"

--- a/public-api/db-cdr/generate-cdr/generate-public-cdr-counts.sh
+++ b/public-api/db-cdr/generate-cdr/generate-public-cdr-counts.sh
@@ -12,70 +12,14 @@
 # --public-project all-of-us-workbench-test --cdr-version 20180130 \
 # --bucket all-of-us-workbench-cloudsql-create
 
-set -xeuo pipefail
-IFS=$'\n\t'
+set -ex
 
+export BQ_PROJECT=$1  # project
+export BQ_DATASET=$2  # dataset
+export PUBLIC_PROJECT=$3 # databrowser project
+export CDR_VERSION=$4 # cdr version
+export BUCKET=$5 # GCS bucket
 
-USAGE="./generate-cdr/generate-public-cdr-counts --bq-project <PROJECT> --bq-dataset <DATASET> --public-project <PROJECT>"
-USAGE="$USAGE --bucket all-of-us-workbench-cloudsql-create --cdr-version=YYYYMMDD --bin-size <BINSIZE>"
-USAGE="$USAGE \n Data is generated from bq-project.bq-dataset and dumped to workbench-project.public<cdr-version>."
-
-BQ_PROJECT="";
-BQ_DATASET="";
-PUBLIC_PROJECT="";
-BUCKET="";
-CDR_VERSION="";
-BIN_SIZE="";
-
-while [ $# -gt 0 ]; do
-  echo "1 is $1"
-  case "$1" in
-    --bq-project) BQ_PROJECT=$2; shift 2;;
-    --bq-dataset) BQ_DATASET=$2; shift 2;;
-    --public-project) PUBLIC_PROJECT=$2; shift 2;;
-    --bucket) BUCKET=$2; shift 2;;
-    --cdr-version) CDR_VERSION=$2; shift 2;;
-    --bin-size) BIN_SIZE=$2; shift 2;;
-    -- ) shift; echo -e "Usage: $USAGE"; break ;;
-    * ) break ;;
-  esac
-done
-
-if [ -z "${BQ_PROJECT}" ]
-then
-  echo -e "Usage: $USAGE"
-  echo -e "Missing bq-project name"
-  exit 1
-fi
-
-if [ -z "${BQ_DATASET}" ]
-then
-  echo -e "Usage: $USAGE"
-  echo -e "Missing bq-dataset name"
-  exit 1
-fi
-
-if [ -z "${PUBLIC_PROJECT}" ]
-then
-  echo -e "Usage: $USAGE"
-  echo -e "Missing public project name"
-  exit 1
-fi
-
-if [ -z "${BUCKET}" ]
-then
-  echo -e "Usage: $USAGE"
-  echo -e "Missing bucket name"
-  exit 1
-fi
-
-#Check cdr_version is not empty
-if [ -z "${CDR_VERSION}" ]
-then
-  echo -e "Usage: $USAGE"
-  echo -e "Missing cdr version"
-  exit 1
-fi
 
 if [ -z "${BIN_SIZE}" ]
 then


### PR DESCRIPTION
1. Remove cdr pipeline commands from docker.
2. Use circle service account instead of test service account while importing files. 