### PR TITLE
[risk=no] fixing post api error on search concepts api

### DIFF
--- a/public-api/src/main/resources/public-api.yaml
+++ b/public-api/src/main/resources/public-api.yaml
@@ -267,6 +267,8 @@ paths:
     post:
       tags:
         - dataBrowser
+      consumes:
+          - application/json
       description: Gets list of matched concepts
       operationId: "searchConcepts"
       parameters:


### PR DESCRIPTION
Search concepts api has a error on content type. Fixing it by adding consumes type. 