### PR TITLE
[risk=no] Docker Sync Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ jobs:
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 2m
       - run:
           working_directory: ~/data-browser/public-api
+          command: ./project.rb run-local-migrations
+      - run:
+          working_directory: ~/data-browser/public-api
           command: ./project.rb start-local-public-api && ./project.rb run-local-public-api-tests && ./project.rb stop-local-public-api
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,6 @@ jobs:
           command: dockerize -wait tcp://127.0.0.1:3306 -timeout 2m
       - run:
           working_directory: ~/data-browser/public-api
-          command: ./project.rb run-local-migrations
-      - run:
-          working_directory: ~/data-browser/public-api
           command: ./project.rb start-local-public-api && ./project.rb run-local-public-api-tests && ./project.rb stop-local-public-api
       - save_cache:
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .externalToolBuilders
 .settings
 /public-api/?/
+/public-api/.docker-sync/
 /public-api/db/?/
 /public-api/.swagger-codegen/*
 /public-api/sa-key.json

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ All of Us public data browser.
 System requirements:
 
   * [Docker CE](https://www.docker.com/community-edition)
+      * __IMPORTANT__: be sure to allocate ~70-80% of available memory and swap to the Docker Engine. This should be 
+        at least 12GB memory and 2GB swap to avoid OOM isues. See https://docs.docker.com/docker-for-mac/#advanced for 
+        screenshots and instructions for Mac.
   * [Ruby](https://www.ruby-lang.org/en/downloads/)
   * [Python](https://www.python.org/downloads/) >= 2.7.9
   * [gcloud](https://cloud.google.com/sdk/docs/#install_the_latest_cloud_tools_version_cloudsdk_current_version)
+  * [Docker sync](https://docker-sync.io)
+    * `gem install docker-sync`
+    * If you'd prefer to install as non-root, you can [follow instructions for user-level install](https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html).
 
 Docker must be installed to build and run code (For Google workstations, see
 go/installdocker.). Ruby is required to run our development scripts, which

--- a/public-api/docker-compose.yaml
+++ b/public-api/docker-compose.yaml
@@ -11,7 +11,7 @@ x-api-defaults: &api-defaults
   # it from the provided build context or use a cached local version.
   # When making changes to this image, you can modify this tag to force all devs
   # to rebuild.
-  image: allofustest/workbench-dev-api:local-3
+  image: allofustest/workbench-dev-api:local-2
   build:
     context: ./src/dev/server
   user: ${UID}

--- a/public-api/docker-compose.yaml
+++ b/public-api/docker-compose.yaml
@@ -24,6 +24,7 @@ x-api-defaults: &api-defaults
     - gradle-cache:/.gradle
     - ~/.config:/.config:cached
     - ~/.gsutil:/.gsutil:cached
+    - db-sync:/w:nocopy
 services:
   scripts:
     <<: *api-defaults
@@ -285,3 +286,5 @@ volumes:
   db:
   gradle-cache:
   gradle-public-api-cache:
+  db-sync:
+    external: true

--- a/public-api/docker-compose.yaml
+++ b/public-api/docker-compose.yaml
@@ -11,7 +11,7 @@ x-api-defaults: &api-defaults
   # it from the provided build context or use a cached local version.
   # When making changes to this image, you can modify this tag to force all devs
   # to rebuild.
-  image: allofustest/workbench-dev-api:local-2
+  image: allofustest/workbench-dev-api:local-3
   build:
     context: ./src/dev/server
   user: ${UID}
@@ -21,10 +21,11 @@ x-api-defaults: &api-defaults
   env_file:
     - db/vars.env
   volumes:
+    - db-sync:/w:nocopy
     - gradle-cache:/.gradle
     - ~/.config:/.config:cached
     - ~/.gsutil:/.gsutil:cached
-    - db-sync:/w:nocopy
+
 services:
   scripts:
     <<: *api-defaults
@@ -34,22 +35,14 @@ services:
       - db/vars.env
     volumes:
       - db:/var/lib/mysql
+
   public-api:
-    build:
-      context: ./src/dev/server
-    user: ${UID}
-    working_dir: /w/public-api
-    volumes:
-      - ..:/w:cached
-      - gradle-public-api-cache:/.gradle
-      - ~/.config:/.config:cached
-      - ~/.gsutil:/.gsutil:cached
+    <<: *api-defaults
     command: gradle :appengineRun
-    env_file:
-      - db/vars.env
     ports:
       - 8083:8083
       - 8084:8002
+
   db-migration:
     depends_on:
       - db
@@ -171,6 +164,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/w/sa-key.json
     env_file:
       - db-cdr/vars.env
+
   db-mysqldump-local-db:
     depends_on:
       - db

--- a/public-api/docker-sync.yml
+++ b/public-api/docker-sync.yml
@@ -1,11 +1,18 @@
 version: "2"
 options:
-  verbose: true
+  compose-file-path: 'docker-compose.yml'
+  # Turn this on if you need to debug something and see verbose logs.
+  verbose: false
+  # The root directory to be used when transforming sync src into absolute path.
+  # accepted values: pwd (current working directory), config_path (the directory where docker-sync.yml is found)
+  project_root: 'pwd'
+
 syncs:
-  #IMPORTANT: ensure this name is unique and does not match your other application container name
-  db-sync: #tip: add -sync and you keep consistent names as a convention
+  db-sync:
+    # This can / should be set to false for most purposes, but may be useful to turn on when debugging / fixing our
+    # docker-sync machinery.
+    notify_terminal: false
     src: '..'
-    dest: '/w:nocopy'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
     # See http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#ignore for the excludes syntax.
     sync_excludes: [
@@ -15,18 +22,12 @@ syncs:
       'public-api/out',
       'public-api/src/generated',
       'node_modules',
-      'tsc-app',
-      'tsc-out',
       'public-ui/coverage',
       'public-ui/dist',
-      'public-ui/src/generated'
+      'public-ui/src/generated',
     ]
     # For AoU, we need docker-sync to write files with the same userid used by the container. We have
     # other machinery that causes our Docker containers to run as the host userid. Using the 'from_host'
     # option here causes docker-sync to do the same.
     sync_userid: 'from_host'
-    sync_user: 'from_host'
     sync_groupid: 'from_host'
-    sync_group: 'from_host'
-    sync_host_ip: 'localhost'
-    sync_host_port: 10872

--- a/public-api/docker-sync.yml
+++ b/public-api/docker-sync.yml
@@ -5,7 +5,7 @@ syncs:
   #IMPORTANT: ensure this name is unique and does not match your other application container name
   db-sync: #tip: add -sync and you keep consistent names as a convention
     src: '..'
-    dest: 'cached'
+    dest: '/w:nocopy'
     host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
     # See http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#ignore for the excludes syntax.
     sync_excludes: [

--- a/public-api/docker-sync.yml
+++ b/public-api/docker-sync.yml
@@ -1,0 +1,32 @@
+version: "2"
+options:
+  verbose: true
+syncs:
+  #IMPORTANT: ensure this name is unique and does not match your other application container name
+  db-sync: #tip: add -sync and you keep consistent names as a convention
+    src: '..'
+    dest: 'cached'
+    host_disk_mount_mode: 'cached' # see https://docs.docker.com/docker-for-mac/osxfs-caching/#cached
+    # See http://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html#ignore for the excludes syntax.
+    sync_excludes: [
+      '.gradle',
+      '.idea',
+      'public-api/build',
+      'public-api/out',
+      'public-api/src/generated',
+      'node_modules',
+      'tsc-app',
+      'tsc-out',
+      'public-ui/coverage',
+      'public-ui/dist',
+      'public-ui/src/generated'
+    ]
+    # For AoU, we need docker-sync to write files with the same userid used by the container. We have
+    # other machinery that causes our Docker containers to run as the host userid. Using the 'from_host'
+    # option here causes docker-sync to do the same.
+    sync_userid: 'from_host'
+    sync_user: 'from_host'
+    sync_groupid: 'from_host'
+    sync_group: 'from_host'
+    sync_host_ip: 'localhost'
+    sync_host_port: 10872

--- a/public-api/libproject/devstart.rb
+++ b/public-api/libproject/devstart.rb
@@ -223,7 +223,6 @@ def setup_local_environment()
 end
 
 def run_local_migrations()
-  ensure_docker_sync()
   setup_local_environment
   # Runs migrations against the local database.
   common = Common.new


### PR DESCRIPTION
Setting up docker-sync in databrowser

Update docker-settings in preferences to use all CPUs and ~70-80% of available memory & swap

Install docker-sync
$ gem install --user-install docker-sync
Add ruby gems to PATH, instructions here https://docker-sync.readthedocs.io/en/latest/getting-started/installation.html

Checkout branch
$ git checkout master
$ git pull
$ git checkout docker_sync

$ cd public-api
$ ./project.rb docker-clean
Docker-sync will be started & stopped as part of the dev script
$ ./project.rb dev-up

Warm dev-up for realistic timings
$ ./project.rb dev-up

Note: Install docker-sync version 0.5.11 for similar configuration which requires specific version of libraries like docker-compose and ruby (~>2.0).

Check here for any dependencies. https://rubygems.org/gems/docker-sync/versions/0.5.11