### PR TITLE
[risk=low] Adding Jest for React unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,10 @@ jobs:
             - ~/data-browser/public-ui/node_modules
           key: public-ui-cache-{{ checksum "~/data-browser/public-ui/package.json" }}
       - run:
+          name: Run React jest tests
+          working_directory: ~/data-browser/public-ui
+          command: yarn test-react --detectOpenHandles --forceExit --runInBand
+      - run:
           name: Lint Angular app
           working_directory: ~/data-browser/public-ui
           command: yarn run lint

--- a/public-ui/package.json
+++ b/public-ui/package.json
@@ -7,6 +7,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test --sourcemaps=false",
+    "test-react": "jest",
     "lint": "ng lint --type-check",
     "e2e": "ng e2e",
     "codegen": "yarn run codegen-clean && yarn run public-codegen-swagger && yarn run public-codegen-swagger-fetch && yarn run public-post-codegen",
@@ -16,6 +17,35 @@
     "public-post-codegen": "sed -i.bak -e 's/OpaqueToken/InjectionToken/' src/publicGenerated/variables.ts",
     "public-codegen-swagger-fetch": "java -jar ../aou-utils/swagger-codegen-cli.jar generate --lang typescript-fetch --input-spec ../public-api/src/main/resources/public-api.yaml --output src/publicGenerated/fetch/ --additional-properties ngVersion=10.2.4",
     "coverage": "ng test --sourcemaps=false --watch=false --code-coverage"
+  },
+  "jest": {
+    "clearMocks": true,
+    "setupFiles": [
+      "./test-shim.js",
+      "./test-setup.js"
+    ],
+    "setupTestFrameworkScriptFile": "./test-setup-script.js",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "spec.ts"
+    ],
+    "moduleDirectories": [
+      "node_modules",
+      "src"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "testMatch": [
+      "**/*.spec.tsx"
+    ],
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "src/tsconfig.jest.json"
+      }
+    }
   },
   "private": true,
   "dependencies": {
@@ -56,6 +86,7 @@
     "rxjs-compat": "^6.0.0-rc.0",
     "stackdriver-errors-js": "^0.4.0",
     "stacktrace-js": "^2.0.0",
+    "ts-jest": "^25.3.0",
     "yarn": "^1.22.10",
     "zone.js": "0.10.3"
   },
@@ -66,15 +97,20 @@
     "@angular/cli": "^10.2.1",
     "@angular/compiler-cli": "^10.2.4",
     "@angular/language-service": "^10.2.4",
+    "@types/enzyme": "^3.10.8",
     "@types/google.analytics": "0.0.36",
     "@types/jasmine": "^2.8.6",
     "@types/jasminewd2": "^2.0.3",
+    "@types/jest": "^23.3.11",
     "@types/node": "^ 7.0.0",
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",
     "codelyzer": "^6.0.1",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.5",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
+    "jest": "^26.6.3",
     "karma": "^1.7.1",
     "karma-chrome-launcher": "~2.1.1",
     "karma-cli": "~1.0.1",
@@ -83,6 +119,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-webdriver-launcher": "^1.0.5",
     "protractor": "~5.1.2",
+    "react-test-renderer": "^17.0.1",
     "ts-node": "~3.0.4",
     "tslint": "^5.9.1",
     "typescript": "^3.9.5"

--- a/public-ui/src/app/shared/components/rh-footer/rh-footer.spec.tsx
+++ b/public-ui/src/app/shared/components/rh-footer/rh-footer.spec.tsx
@@ -1,0 +1,11 @@
+import {mount} from 'enzyme';
+import * as React from 'react';
+
+import {RhFooter} from './rh-footer';
+
+describe('RhFooter', () => {
+  it('should render', () => {
+    const wrapper = mount(<RhFooter/>);
+    expect(wrapper).toBeTruthy();
+  });
+});

--- a/public-ui/src/app/shared/components/rh-footer/rh-footer.tsx
+++ b/public-ui/src/app/shared/components/rh-footer/rh-footer.tsx
@@ -5,7 +5,7 @@ import { BaseReactWrapper } from 'app/data-browser/base-react/base-react.wrapper
 import { menuItems, socialLinks } from 'app/shared/services/header-footer.service';
 import { environment } from 'environments/environment';
 
-const RhFooter: React.FunctionComponent = () => {
+export const RhFooter: React.FunctionComponent = () => {
   return <footer>
     <div className='db-container'>
       <div className='site-branding-container'>

--- a/public-ui/src/tsconfig.app.json
+++ b/public-ui/src/tsconfig.app.json
@@ -8,6 +8,8 @@
   },
   "exclude": [
     "test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+
   ]
 }

--- a/public-ui/src/tsconfig.jest.json
+++ b/public-ui/src/tsconfig.jest.json
@@ -1,0 +1,24 @@
+// TypeScript compile settings for Jest tests (which cover our React components).
+//
+// This file is referred to from ui/package.json
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    // No outDir needs to be specified here, as test runs will not produce output files anyway.
+    "baseUrl": "./",
+    "module": "commonjs",
+    "target": "es5",
+    "types": [
+      "jest",
+      "node"
+    ],
+    "jsx": "react"
+  },
+  "files": [
+    "polyfills.ts"
+  ],
+  "include": [
+    "**/*.spec.tsx",
+    "**/*.d.ts",
+  ]
+}

--- a/public-ui/test-setup-script.js
+++ b/public-ui/test-setup-script.js
@@ -1,0 +1,14 @@
+global.beforeEach(() => {
+  const appRoot = document.createElement('div');
+  appRoot.setAttribute('id', 'root');
+  document.body.appendChild(appRoot);
+
+  const popupRoot = document.createElement('div');
+  popupRoot.setAttribute('id', 'popup-root');
+  document.body.appendChild(popupRoot);
+});
+
+global.afterEach(() => {
+  document.body.removeChild(document.getElementById('root'));
+  document.body.removeChild(document.getElementById('popup-root'));
+});

--- a/public-ui/test-setup.js
+++ b/public-ui/test-setup.js
@@ -1,0 +1,10 @@
+/**
+ * Defines the React 16 Adapter for Enzyme.
+ *
+ * @link http://airbnb.io/enzyme/docs/installation/#working-with-react-16
+ * @copyright 2017 Airbnb, Inc.
+ */
+const enzyme = require("enzyme");
+const Adapter = require("enzyme-adapter-react-16");
+
+enzyme.configure({ adapter: new Adapter() });

--- a/public-ui/test-shim.js
+++ b/public-ui/test-shim.js
@@ -1,0 +1,1 @@
+require('mutationobserver-shim');


### PR DESCRIPTION
- Adds Jest so we can write tests for React components
- Modified the Circle CI config so Jest tests will run as part of `public-ui-build-test`
- Included a basic render test for `RhFooter` component. We should include a similar render test with each component we convert. If there are existing Angular tests that cover functionality of the component, we should try to convert those as well.