### PR TITLE
[risk=no] Add stores for route data

### DIFF
--- a/public-ui/src/app/utils/navigation.tsx
+++ b/public-ui/src/app/utils/navigation.tsx
@@ -1,7 +1,13 @@
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
 export const NavStore = {
   navigate: undefined,
   navigateByUrl: undefined
 };
+
+export const urlParamsStore = new BehaviorSubject<any>({});
+export const queryParamsStore = new BehaviorSubject<any>({});
+export const routeConfigDataStore = new BehaviorSubject<any>({});
 
 // NOTE: Because these are wired up directly to the router component,
 // all navigation done from here will effectively use absolute paths.

--- a/public-ui/src/app/views/app/app.component.ts
+++ b/public-ui/src/app/views/app/app.component.ts
@@ -7,6 +7,7 @@ import {
   Router,
 } from '@angular/router';
 import {initializeAnalytics} from 'app/utils/google_analytics';
+import {queryParamsStore, routeConfigDataStore, urlParamsStore} from 'app/utils/navigation';
 import { environment } from 'environments/environment';
 import {filter} from 'rxjs/operators';
 
@@ -71,10 +72,20 @@ export class AppComponent implements OnInit {
         if (event instanceof NavigationEnd && event.url === '/') {
           this.noHeaderMenu = true;
         }
+        if (event instanceof NavigationEnd) {
+          const {snapshot: {params, queryParams, routeConfig}} = this.getLeafRoute();
+          urlParamsStore.next(params);
+          queryParamsStore.next(queryParams);
+          routeConfigDataStore.next(routeConfig.data);
+        }
         this.setTitleFromRoute(event);
       });
 
     initializeAnalytics();
+  }
+
+  getLeafRoute(route = this.activatedRoute) {
+    return route.firstChild ? this.getLeafRoute(route.firstChild) : route;
   }
 
   /**


### PR DESCRIPTION
Adds `urlParamsStore`, `queryParamsStore` and `routeConfigDataStore` store for accessing route params and data in React components. `routeConfigDataStore` will most likely only be used for breadcrumbs once we convert it.