### PR TITLE
[risk=no] Adding generate circle key script

### DIFF
--- a/public-api/db-cdr/generate-cdr/generate_circle_key/generate_circle_key.sh
+++ b/public-api/db-cdr/generate-cdr/generate_circle_key/generate_circle_key.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+GCLOUD_CREDENTIALS_KEY=$(openssl rand -base64 32)
+GCLOUD_CREDENTIALS=$(openssl enc -md sha256 -aes-256-cbc -in "$1" -base64 -A  -k "$GCLOUD_CREDENTIALS_KEY")
+
+echo "GCLOUD_CREDENTIALS=$GCLOUD_CREDENTIALS"
+echo "GCLOUD_CREDENTIALS_KEY=$GCLOUD_CREDENTIALS_KEY"


### PR DESCRIPTION
This script outputs the credentials which have to be put in env variables on circle ci to run the jobs.