### PR TITLE
[DB-1270][risk=no]Topnav breakpoints and font dispaly differently in Firefox

### DIFF
--- a/public-ui/src/app/shared/components/rh-header/rh-header.component.css
+++ b/public-ui/src/app/shared/components/rh-header/rh-header.component.css
@@ -318,7 +318,6 @@
     position: relative;
     display: block;
     font-size: 18px;
-    font-weight: bold;
     font-stretch: normal;
     font-style: normal;
     line-height: 1;


### PR DESCRIPTION
![image](https://github.com/all-of-us/data-browser/assets/860209/62870910-02b0-4c20-b87f-64803c8b74ef)
