### PR TITLE
[DB-1290][risk=no] fixes and tweaks to genomic infinite scroll:

### DIFF
--- a/public-ui/src/app/data-browser/views/genomic-view/components/genomic-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/genomic-search.component.tsx
@@ -58,7 +58,7 @@ interface State {
   filterMetadata: GenomicFilters;
   submittedFilterMetadata: GenomicFilters;
   sortMetadata: SortMetadata;
-  filtered: boolean
+  filtered: boolean;
 }
 
 export class GenomicSearchComponent extends React.Component<Props, State> {

--- a/public-ui/src/app/data-browser/views/genomic-view/components/genomic-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/genomic-search.component.tsx
@@ -50,6 +50,7 @@ interface Props {
   filterMetadata: GenomicFilters;
   submittedFilterMetadata: GenomicFilters;
   sortMetadata: SortMetadata;
+  scrollClean: boolean;
 }
 
 interface State {
@@ -81,13 +82,13 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
       this.setState({ filterMetadata: filterMetadata });
     }
     if (prevProps.submittedFilterMetadata !== submittedFilterMetadata) {
-        this.setState({submittedFilterMetadata: submittedFilterMetadata});
+      this.setState({ submittedFilterMetadata: submittedFilterMetadata });
     }
   }
 
   handlePageChange(info) {
     this.props.onPageChange(info);
-    { !environment.infiniteSrcoll &&  this.scrollDiv.current.scrollIntoView({ behavior: "smooth" });}
+    { !environment.infiniteSrcoll && this.scrollDiv.current.scrollIntoView({ behavior: "smooth" }); }
   }
 
   handleRowCountChange(info) {
@@ -110,14 +111,14 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
   render() {
     const { searchTerm, filterMetadata, sortMetadata, submittedFilterMetadata } = this.state;
     const { currentPage, loadingResults, searchResults, variantListSize, loadingVariantListSize, onSearchInput,
-      rowCount } = this.props;
+      rowCount,scrollClean } = this.props;
     return <React.Fragment>
       <div style={styles.titleBox}>
         <p style={styles.boxHeading} ref={this.scrollDiv}>
-        Explore allele frequencies for a gene or genomic region and drill down into variants to view select annotations and genetic ancestry associations. 
-        Variants are based on short-read whole genome sequencing and called against the GRCh38/hg38 genome reference. Learn more: &#32;
-          <a style={{color:'#1f79b8'}} target="_blank" href='https://aousupporthelp.zendesk.com/hc/en-us/articles/4615256690836-Variant-Annotation-Table'>
-          Variant Annotation Table.
+          Explore allele frequencies for a gene or genomic region and drill down into variants to view select annotations and genetic ancestry associations.
+          Variants are based on short-read whole genome sequencing and called against the GRCh38/hg38 genome reference. Learn more: &#32;
+          <a style={{ color: '#1f79b8' }} target="_blank" href='https://aousupporthelp.zendesk.com/hc/en-us/articles/4615256690836-Variant-Annotation-Table'>
+            Variant Annotation Table.
           </a>
         </p>
       </div>
@@ -131,7 +132,8 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
         filterMetadata={filterMetadata}
         sortMetadata={sortMetadata}
         submittedFilterMetadata={submittedFilterMetadata}
-        onSortChange={(e) => this.handleSortClick(e)} />
+        onSortChange={(e) => this.handleSortClick(e)}
+        scrollClean={scrollClean} />
       <VariantTableComponent
         loadingResults={loadingResults}
         loadingVariantListSize={loadingVariantListSize}
@@ -142,10 +144,11 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
         onRowCountChange={(info: any) => this.handleRowCountChange(info)}
         onPageChange={(info: any) => this.handlePageChange(info)}
         onSortClick={(sortMetadata: any) => this.handleSortClick(sortMetadata)}
-        onScrollBottom={()=>{environment.infiniteSrcoll && this.handleScrollBottom()}}
+        onScrollBottom={() => { environment.infiniteSrcoll && this.handleScrollBottom() }}
         currentPage={currentPage}
         rowCount={rowCount}
-        sortMetadata={sortMetadata} />
+        sortMetadata={sortMetadata}
+         />
     </React.Fragment>;
   }
 }

--- a/public-ui/src/app/data-browser/views/genomic-view/components/genomic-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/genomic-search.component.tsx
@@ -58,6 +58,7 @@ interface State {
   filterMetadata: GenomicFilters;
   submittedFilterMetadata: GenomicFilters;
   sortMetadata: SortMetadata;
+  filtered: boolean
 }
 
 export class GenomicSearchComponent extends React.Component<Props, State> {
@@ -70,6 +71,7 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
       filterMetadata: this.props.filterMetadata,
       sortMetadata: this.props.sortMetadata,
       submittedFilterMetadata: this.props.submittedFilterMetadata,
+      filtered: false
     };
   }
 
@@ -102,6 +104,10 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
 
   handleFilterSubmit(filteredMetadata, sortMetadata) {
     this.props.onFilterSubmit(filteredMetadata, sortMetadata);
+    this.setState({filtered:true});
+    setTimeout(() => {
+      this.setState({filtered:false});
+    }, 1000);
   }
 
   handleScrollBottom() {
@@ -109,7 +115,7 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
   }
 
   render() {
-    const { searchTerm, filterMetadata, sortMetadata, submittedFilterMetadata } = this.state;
+    const { searchTerm, filterMetadata, sortMetadata, submittedFilterMetadata,filtered } = this.state;
     const { currentPage, loadingResults, searchResults, variantListSize, loadingVariantListSize, onSearchInput,
       rowCount,scrollClean } = this.props;
     return <React.Fragment>
@@ -148,6 +154,7 @@ export class GenomicSearchComponent extends React.Component<Props, State> {
         currentPage={currentPage}
         rowCount={rowCount}
         sortMetadata={sortMetadata}
+        filtered = {filtered}
          />
     </React.Fragment>;
   }

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-filter.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-filter.component.tsx
@@ -147,6 +147,8 @@ export class VariantFilterComponent extends React.Component<Props, State> {
         sortMetadata['variantId'].sortDirection = "asc";
 
         this.setState({ cleared: false, filteredMetadata: this.state.filteredMetadata, sortMetadata: sortMetadata }, () => this.setState({ cleared: true }));
+        this.props.onFilterSubmit(this.state.filteredMetadata, sortMetadata);
+        
     }
 
     render() {

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {VariantFilterChips} from './variant-filter-chips.component'
+import { VariantFilterChips } from './variant-filter-chips.component'
 import { environment } from "environments/environment";
 import { SearchComponent } from "app/data-browser/search/home-search.component";
 import { VariantFilterComponent } from "app/data-browser/views/genomic-view/components/variant-filter.component";
@@ -27,13 +27,13 @@ const styles = reactStyles({
     display: "flex",
     alignItems: "center",
     height: "1rem",
-    paddingTop:".5rem"
+    paddingTop: ".5rem"
   },
   filterBtn: {
     fontFamily: "gothamBold",
     color: "#216FB4",
     cursor: "Pointer",
-    width:"fit-content"
+    width: "fit-content"
   },
   filterContainer: {
     position: "relative",
@@ -57,8 +57,8 @@ const css = `
 `;
 
 export interface Chip {
-    cat: any;
-    data: GenomicFilters;
+  cat: any;
+  data: GenomicFilters;
 }
 interface Props {
   onSearchTerm: Function;
@@ -73,39 +73,39 @@ interface Props {
   loadingVariantListSize: boolean;
 }
 interface State {
-    filteredMetadata: GenomicFilters;
-    filteredMetaMap: GenomicFilters;
-    submittedFilterMetadata: GenomicFilters;
-    searchWord: string;
-    filterShow: Boolean;
-    filterMetadata: GenomicFilters;
-    sortMetadata: SortMetadata;
+  filteredMetadata: GenomicFilters;
+  filteredMetaMap: GenomicFilters;
+  submittedFilterMetadata: GenomicFilters;
+  searchWord: string;
+  filterShow: Boolean;
+  filterMetadata: GenomicFilters;
+  sortMetadata: SortMetadata;
 }
 
 export class VariantSearchComponent extends React.Component<Props, State> {
-    private filterWrapperRef;
-    constructor(props: Props) {
-        super(props);
-        this.state = {
-            searchWord: '',
-            filterShow: false,
-            filteredMetadata: undefined,
-            filteredMetaMap: undefined,
-            filterMetadata: this.props.filterMetadata,
-            submittedFilterMetadata: this.props.submittedFilterMetadata,
-            sortMetadata: this.props.sortMetadata,
-        };
-        if (this.state.searchWord !== '') {
-            this.props.onSearchTerm(this.state.searchWord);
-        }
-        this.filterWrapperRef = React.createRef();
-        this.handleClickOutside = this.handleClickOutside.bind(this);
+  private filterWrapperRef;
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      searchWord: '',
+      filterShow: false,
+      filteredMetadata: undefined,
+      filteredMetaMap: undefined,
+      filterMetadata: this.props.filterMetadata,
+      submittedFilterMetadata: this.props.submittedFilterMetadata,
+      sortMetadata: this.props.sortMetadata,
+    };
+    if (this.state.searchWord !== '') {
+      this.props.onSearchTerm(this.state.searchWord);
     }
+    this.filterWrapperRef = React.createRef();
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
 
 
   handleChange(val: string) {
-      this.props.onSearchTerm(val);
-      this.setState({ searchWord: val, filteredMetaMap: null, filterShow: false });
+    this.props.onSearchTerm(val);
+    this.setState({ searchWord: val, filteredMetaMap: null, filterShow: false });
   }
 
   componentDidMount() {
@@ -117,7 +117,7 @@ export class VariantSearchComponent extends React.Component<Props, State> {
   }
 
   handleClickOutside(event) {
-    const {filterShow} = this.state;
+    const { filterShow } = this.state;
     if (this.filterWrapperRef && !this.filterWrapperRef.current.contains(event.target)) {
       if (filterShow) {
         this.setState({ filterShow: !this.state.filterShow });
@@ -129,79 +129,79 @@ export class VariantSearchComponent extends React.Component<Props, State> {
     const { searchTerm, filterMetadata, submittedFilterMetadata } = this.props;
 
     if (prevProps.searchTerm !== searchTerm) {
-        this.setState({ searchWord: searchTerm });
+      this.setState({ searchWord: searchTerm });
     }
     if (prevProps.filterMetadata !== filterMetadata) {
-        this.setState({ filterMetadata: filterMetadata});
+      this.setState({ filterMetadata: filterMetadata });
     }
     if (prevProps.submittedFilterMetadata !== submittedFilterMetadata) {
-        this.setState({ submittedFilterMetadata: submittedFilterMetadata});
+      this.setState({ submittedFilterMetadata: submittedFilterMetadata });
     }
   }
 
-    showFilter() {
-        this.setState({ filterShow: !this.state.filterShow });
-    }
+  showFilter() {
+    this.setState({ filterShow: !this.state.filterShow });
+  }
 
-    handleFilterSubmit(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) {
-        this.setState({filteredMetadata: filteredMetadata});
-        this.props.onFilterSubmit(filteredMetadata, sortMetadata);
-        this.setState({ filterShow: false });
-    }
+  handleFilterSubmit(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) {
+    this.setState({ filteredMetadata: filteredMetadata });
+    this.props.onFilterSubmit(filteredMetadata, sortMetadata);
+    this.setState({ filterShow: false });
+  }
 
-    handleChipChange(changes) {
-        // this.setState({ filteredMetaMap: changes });
-        const sortMetadata = this.state.sortMetadata;
-        this.handleFilterSubmit(changes, sortMetadata);
-    }
+  handleChipChange(changes) {
+    // this.setState({ filteredMetaMap: changes });
+    const sortMetadata = this.state.sortMetadata;
+    this.handleFilterSubmit(changes, sortMetadata);
+  }
 
-    handleSortChange(sortChange: any) {
-        this.setState({sortMetadata: sortChange});
-        this.props.onSortChange(sortChange);
-    }
+  handleSortChange(sortChange: any) {
+    this.setState({ sortMetadata: sortChange });
+    this.props.onSortChange(sortChange);
+  }
 
-    render() {
-        const { searchWord, filterShow, sortMetadata, filteredMetadata, submittedFilterMetadata } = this.state;
-        const {filterMetadata} = this.props
-        const { variantListSize, loadingResults, loadingVariantListSize } = this.props;
-        const variantListSizeDisplay = variantListSize ? variantListSize.toLocaleString() : 0;
-        return <React.Fragment>
-            <style>{css}</style>
-            <div className='search-container'>
-                <div style={styles.searchBar}>
-                    <SearchComponent value={searchWord} searchTitle='' domain='genomics'
-                        onChange={(val: string) => this.handleChange(val)}
-                        onClear={() => this.handleChange('')} placeholderText='Search by gene, variant, rs number, or genomic region' />
-                </div>
-                <div style={styles.searchHelpText}>
-                    Examples by query type: <br></br>
-                    <strong>Gene:</strong> BRCA2 <br></br>
-                    <strong>Variant:</strong> 13-32355250-T-C <br></br>
-                    <strong>RS Number:</strong> rs169547 <br></br>
-                    <strong>Genomic Region:</strong> chr13:32355000-32375000
-                </div>
-            </div>
-            {((!loadingResults && !loadingVariantListSize) && (variantListSize > 0) && environment.genoFilters) ? <div onClick={() => this.showFilter()}
-                style={styles.filterBtn}><ClrIcon shape='filter-2' /> Filter & Sort</div> : <div style={{height:'1rem'}}></div>}
-            {submittedFilterMetadata &&
-                <VariantFilterChips
-                    filteredMetadata={submittedFilterMetadata}
-                    onChipChange={(changes) => this.handleChipChange(changes)} />}
-            <React.Fragment>{
-                (!loadingResults && !loadingVariantListSize && searchWord) && <strong style={styles.resultSize} >{(!loadingResults && !loadingVariantListSize) ? variantListSizeDisplay :
-                                <span style={styles.loading}><Spinner /></span>} variants found</strong>
-                }</React.Fragment>
-            {environment.genoFilters && <div style={styles.filterContainer} ref={this.filterWrapperRef}>
-                {((!loadingResults && !loadingVariantListSize) && filterShow) &&
-                    <VariantFilterComponent
-                        filterMetadata={filterMetadata}
-                        sortMetadata={sortMetadata}
-                        onFilterSubmit={(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) => this.handleFilterSubmit(filteredMetadata, sortMetadata)}
-                        onSortChange={(e) => this.handleSortChange(e)}
-                        />}
-            </div>
-            }
+  render() {
+    const { searchWord, filterShow, sortMetadata, filteredMetadata, submittedFilterMetadata } = this.state;
+    const { filterMetadata } = this.props
+    const { variantListSize, loadingResults, loadingVariantListSize } = this.props;
+    const variantListSizeDisplay = variantListSize ? variantListSize.toLocaleString() : 0;
+    return <React.Fragment>
+      <style>{css}</style>
+      <div className='search-container'>
+        <div style={styles.searchBar}>
+          <SearchComponent value={searchWord} searchTitle='' domain='genomics'
+            onChange={(val: string) => this.handleChange(val)}
+            onClear={() => this.handleChange('')} placeholderText='Search by gene, variant, rs number, or genomic region' />
+        </div>
+        <div style={styles.searchHelpText}>
+          Examples by query type: <br></br>
+          <strong>Gene:</strong> BRCA2 <br></br>
+          <strong>Variant:</strong> 13-32355250-T-C <br></br>
+          <strong>RS Number:</strong> rs169547 <br></br>
+          <strong>Genomic Region:</strong> chr13:32355000-32375000
+        </div>
+      </div>
+      {((!loadingResults && !loadingVariantListSize) && (variantListSize > 0) && environment.genoFilters) ? <div onClick={() => this.showFilter()}
+        style={styles.filterBtn}><ClrIcon shape='filter-2' /> Filter & Sort</div> : <div style={{ height: '1rem' }}></div>}
+      {submittedFilterMetadata &&
+        <VariantFilterChips
+          filteredMetadata={submittedFilterMetadata}
+          onChipChange={(changes) => this.handleChipChange(changes)} />}
+      <React.Fragment>{
+        (!loadingResults && !loadingVariantListSize && searchWord) ? <strong style={styles.resultSize} >{(!loadingResults && !loadingVariantListSize) ? variantListSizeDisplay :
+          <span style={styles.loading}><Spinner /></span>} variants found</strong> : <div style={{ height: '1rem' }}></div>
+      }</React.Fragment>
+      {environment.genoFilters && <div style={styles.filterContainer} ref={this.filterWrapperRef}>
+        {((!loadingResults && !loadingVariantListSize) && filterShow) &&
+          <VariantFilterComponent
+            filterMetadata={filterMetadata}
+            sortMetadata={sortMetadata}
+            onFilterSubmit={(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) => this.handleFilterSubmit(filteredMetadata, sortMetadata)}
+            onSortChange={(e) => this.handleSortChange(e)}
+          />}
+      </div>
+      }
 
-        </React.Fragment>;
-    }
+    </React.Fragment>;
+  }
 }

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -204,7 +204,7 @@ export class VariantSearchComponent extends React.Component<Props, State> {
             scrollClean ? <div> </div> : <strong style={styles.resultSize} >{variantListSizeDisplay} variants found</strong>
         }</React.Fragment>
       {environment.genoFilters && <div style={styles.filterContainer} ref={this.filterWrapperRef}>
-        {((!loadingResults && !loadingVariantListSize) && filterShow) &&
+        { filterShow &&
           <VariantFilterComponent
             filterMetadata={filterMetadata}
             sortMetadata={sortMetadata}

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -103,10 +103,11 @@ export class VariantSearchComponent extends React.Component<Props, State> {
   }
 
 
-  handleChange(val: string) {
+  handleChange = (val: string) => {
     this.props.onSearchTerm(val);
     this.setState({ searchWord: val, filteredMetaMap: null, filterShow: false });
   }
+  
 
   componentDidMount() {
     document.addEventListener("mousedown", this.handleClickOutside);

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -105,12 +105,12 @@ export class VariantSearchComponent extends React.Component<Props, State> {
     this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
-
   handleChange(val: string) {
-    if (val == '') { this.setState({ scrollClean: true }) }
+    if (val == '') {this.setState({ scrollClean: true }) }
     this.props.onSearchTerm(val);
     this.setState({ searchWord: val, filteredMetaMap: null, filterShow: false });
   }
+  
   componentWillUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>, nextContext: any): void {
     if (this.props.scrollClean != nextProps.scrollClean) {
       this.setState({ scrollClean: nextProps.scrollClean })

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -103,11 +103,10 @@ export class VariantSearchComponent extends React.Component<Props, State> {
   }
 
 
-  handleChange = (val: string) => {
+  handleChange(val: string) {
     this.props.onSearchTerm(val);
     this.setState({ searchWord: val, filteredMetaMap: null, filterShow: false });
   }
-  
 
   componentDidMount() {
     document.addEventListener("mousedown", this.handleClickOutside);

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -71,15 +71,17 @@ interface Props {
   onSortChange: Function;
   loadingResults: boolean;
   loadingVariantListSize: boolean;
+  scrollClean: boolean;
 }
 interface State {
   filteredMetadata: GenomicFilters;
   filteredMetaMap: GenomicFilters;
   submittedFilterMetadata: GenomicFilters;
-  searchWord: string;
-  filterShow: Boolean;
   filterMetadata: GenomicFilters;
   sortMetadata: SortMetadata;
+  filterShow: Boolean;
+  searchWord: string;
+  scrollClean: boolean;
 }
 
 export class VariantSearchComponent extends React.Component<Props, State> {
@@ -94,6 +96,7 @@ export class VariantSearchComponent extends React.Component<Props, State> {
       filterMetadata: this.props.filterMetadata,
       submittedFilterMetadata: this.props.submittedFilterMetadata,
       sortMetadata: this.props.sortMetadata,
+      scrollClean: this.props.scrollClean
     };
     if (this.state.searchWord !== '') {
       this.props.onSearchTerm(this.state.searchWord);
@@ -104,10 +107,15 @@ export class VariantSearchComponent extends React.Component<Props, State> {
 
 
   handleChange(val: string) {
+    if (val == '') { this.setState({ scrollClean: true }) }
     this.props.onSearchTerm(val);
     this.setState({ searchWord: val, filteredMetaMap: null, filterShow: false });
   }
-
+  componentWillUpdate(nextProps: Readonly<Props>, nextState: Readonly<State>, nextContext: any): void {
+    if (this.props.scrollClean != nextProps.scrollClean) {
+      this.setState({ scrollClean: nextProps.scrollClean })
+    }
+  }
   componentDidMount() {
     document.addEventListener("mousedown", this.handleClickOutside);
   }
@@ -161,7 +169,7 @@ export class VariantSearchComponent extends React.Component<Props, State> {
   }
 
   render() {
-    const { searchWord, filterShow, sortMetadata, filteredMetadata, submittedFilterMetadata } = this.state;
+    const { searchWord, filterShow, sortMetadata, submittedFilterMetadata, scrollClean } = this.state;
     const { filterMetadata } = this.props
     const { variantListSize, loadingResults, loadingVariantListSize } = this.props;
     const variantListSizeDisplay = variantListSize ? variantListSize.toLocaleString() : 0;
@@ -182,15 +190,19 @@ export class VariantSearchComponent extends React.Component<Props, State> {
         </div>
       </div>
       {((!loadingResults && !loadingVariantListSize) && (variantListSize > 0) && environment.genoFilters) ? <div onClick={() => this.showFilter()}
-        style={styles.filterBtn}><ClrIcon shape='filter-2' /> Filter & Sort</div> : <div style={{ height: '1rem' }}></div>}
+        style={styles.filterBtn}><ClrIcon shape='filter-2' /> Filter & Sort</div> :
+        scrollClean ? <div> </div> : <div onClick={() => this.showFilter()}
+          style={styles.filterBtn}><ClrIcon shape='filter-2' /> Filter & Sort</div>}
       {submittedFilterMetadata &&
         <VariantFilterChips
           filteredMetadata={submittedFilterMetadata}
           onChipChange={(changes) => this.handleChipChange(changes)} />}
-      <React.Fragment>{
-        (!loadingResults && !loadingVariantListSize && searchWord) ? <strong style={styles.resultSize} >{(!loadingResults && !loadingVariantListSize) ? variantListSizeDisplay :
-          <span style={styles.loading}><Spinner /></span>} variants found</strong> : <div style={{ height: '1rem' }}></div>
-      }</React.Fragment>
+      <React.Fragment>
+        {
+          (!loadingResults && !loadingVariantListSize && searchWord) ? <strong style={styles.resultSize} >{(!loadingResults && !loadingVariantListSize) ? variantListSizeDisplay :
+            <span style={styles.loading}><Spinner /></span>} variants found</strong> :
+            scrollClean ? <div> </div> : <strong style={styles.resultSize} >{variantListSizeDisplay} variants found</strong>
+        }</React.Fragment>
       {environment.genoFilters && <div style={styles.filterContainer} ref={this.filterWrapperRef}>
         {((!loadingResults && !loadingVariantListSize) && filterShow) &&
           <VariantFilterComponent

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
@@ -182,19 +182,13 @@ export class VariantTableComponent extends React.Component<Props, State> {
       const scrollArea = document.querySelector('.scroll-area');
       if (scrollArea) {
         // event.preventDefault();
-        const buffer = 12000;
         const scrollTop = scrollArea.scrollTop;
         const scrollHeight = scrollArea.scrollHeight;
-        const clientHeight = scrollArea.clientHeight;
         // trigger scroll at 35%
         const scrolledToBottom = scrollTop / scrollHeight > .35;
         if (scrolledToBottom && this.props.currentPage < this.props.variantListSize / this.props.rowCount) {
-          const { searchTerm } = this.props;
-          console.log();
-          
           // Fetch new data and append
           this.props.onScrollBottom();
-          // this.setState({loading:false})
         }
       }
     }, 150);

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
@@ -142,8 +142,6 @@ interface State {
   loading: boolean;
   searchResults: Variant[];
   sortMetadata: any;
-  currentPage: number;
-  rowCount: number;
 
 }
 
@@ -154,8 +152,6 @@ export class VariantTableComponent extends React.Component<Props, State> {
       loading: props.loadingResults,
       searchResults: props.searchResults,
       sortMetadata: props.sortMetadata,
-      currentPage: props.currentPage,
-      rowCount:  props.searchResults.length < 100 ? props.searchResults.length : 100
     };
   }
   scrollAreaRef: React.RefObject<HTMLDivElement> = React.createRef();
@@ -177,7 +173,7 @@ export class VariantTableComponent extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Readonly<Props>) {
     const { searchResults, loadingResults, filtered } = this.props;
     // console.log(loadingResults,'loadingResults');
-    console.log(this.state.rowCount);
+
     
     if (filtered) {
       this.scrollAreaToTop();
@@ -200,7 +196,7 @@ export class VariantTableComponent extends React.Component<Props, State> {
         const scrollHeight = scrollArea.scrollHeight;
         // trigger scroll at 35%
         const scrolledToBottom = scrollTop / scrollHeight > .35;
-        if (scrolledToBottom && this.state.currentPage < this.props.variantListSize / this.props.rowCount) {
+        if (scrolledToBottom && this.props.currentPage < this.props.variantListSize / this.props.rowCount) {
           // Fetch new data and append
           this.props.onScrollBottom();
         }
@@ -256,9 +252,9 @@ export class VariantTableComponent extends React.Component<Props, State> {
 
 
   render() {
-    const { loadingVariantListSize, loadingResults, variantListSize } =
+    const { loadingVariantListSize, loadingResults, variantListSize, rowCount, currentPage } =
       this.props;
-    const { loading, searchResults, sortMetadata, currentPage, rowCount } = this.state;
+    const { loading, searchResults, sortMetadata } = this.state;
     return (
       <React.Fragment>
         <style>{css}</style>

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
@@ -181,15 +181,17 @@ export class VariantTableComponent extends React.Component<Props, State> {
     this.debounceTimer = setTimeout(() => {
       const scrollArea = document.querySelector('.scroll-area');
       if (scrollArea) {
-        event.preventDefault();
+        // event.preventDefault();
         const buffer = 12000;
         const scrollTop = scrollArea.scrollTop;
         const scrollHeight = scrollArea.scrollHeight;
         const clientHeight = scrollArea.clientHeight;
-        const scrolledToBottom = scrollTop + clientHeight + buffer >= scrollHeight;
-
+        // trigger scroll at 35%
+        const scrolledToBottom = scrollTop / scrollHeight > .35;
         if (scrolledToBottom && this.props.currentPage < this.props.variantListSize / this.props.rowCount) {
           const { searchTerm } = this.props;
+          console.log();
+          
           // Fetch new data and append
           this.props.onScrollBottom();
           // this.setState({loading:false})

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
@@ -182,7 +182,7 @@ export class VariantTableComponent extends React.Component<Props, State> {
       const scrollArea = document.querySelector('.scroll-area');
       if (scrollArea) {
         event.preventDefault();
-        const buffer = 1000;
+        const buffer = 2000;
         const scrollTop = scrollArea.scrollTop;
         const scrollHeight = scrollArea.scrollHeight;
         const clientHeight = scrollArea.clientHeight;

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
@@ -182,14 +182,13 @@ export class VariantTableComponent extends React.Component<Props, State> {
       const scrollArea = document.querySelector('.scroll-area');
       if (scrollArea) {
         event.preventDefault();
-        const buffer = 2000;
+        const buffer = 12000;
         const scrollTop = scrollArea.scrollTop;
         const scrollHeight = scrollArea.scrollHeight;
         const clientHeight = scrollArea.clientHeight;
         const scrolledToBottom = scrollTop + clientHeight + buffer >= scrollHeight;
 
         if (scrolledToBottom && this.props.currentPage < this.props.variantListSize / this.props.rowCount) {
-          console.log('Scrolled to the bottom');
           const { searchTerm } = this.props;
           // Fetch new data and append
           this.props.onScrollBottom();

--- a/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
@@ -123,6 +123,7 @@ interface State {
   submittedFilterMetadata: GenomicFilters;
   filteredMetadata: GenomicFilters;
   filterChipsShow: boolean;
+  scrollClean: boolean;
 }
 
 class SortMetadataClass implements SortMetadata {
@@ -190,15 +191,16 @@ export const GenomicViewComponent = withRouteData(
         filterMetadata: null,
         filteredMetadata: undefined,
         submittedFilterMetadata: undefined,
+        scrollClean: true,
         sortMetadata: new SortMetadataClass(
-                    new SortColumnDetailsClass(true, "asc", 1),
-                    new SortColumnDetailsClass(false, "asc", 2),
-                    new SortColumnDetailsClass(false, "asc", 3),
-                    new SortColumnDetailsClass(false, "asc", 4),
-                    new SortColumnDetailsClass(false, "asc", 5),
-                    new SortColumnDetailsClass(false, "asc", 6),
-                    new SortColumnDetailsClass(false, "asc", 7),
-                    new SortColumnDetailsClass(false, "asc", 8),
+          new SortColumnDetailsClass(true, "asc", 1),
+          new SortColumnDetailsClass(false, "asc", 2),
+          new SortColumnDetailsClass(false, "asc", 3),
+          new SortColumnDetailsClass(false, "asc", 4),
+          new SortColumnDetailsClass(false, "asc", 5),
+          new SortColumnDetailsClass(false, "asc", 6),
+          new SortColumnDetailsClass(false, "asc", 7),
+          new SortColumnDetailsClass(false, "asc", 8),
         ),
       };
     }
@@ -222,14 +224,14 @@ export const GenomicViewComponent = withRouteData(
     }, 1000);
 
     clearSortMetadata() {
-        const { sortMetadata } = this.state;
-        for (const smKey in sortMetadata) {
-            sortMetadata[smKey].sortActive = false;
-            sortMetadata[smKey].sortDirection = "asc";
-        }
-        sortMetadata['variantId'].sortActive = true;
-        sortMetadata['variantId'].sortDirection = "asc";
-        this.setState({sortMetadata: sortMetadata});
+      const { sortMetadata } = this.state;
+      for (const smKey in sortMetadata) {
+        sortMetadata[smKey].sortActive = false;
+        sortMetadata[smKey].sortDirection = "asc";
+      }
+      sortMetadata['variantId'].sortActive = true;
+      sortMetadata['variantId'].sortDirection = "asc";
+      this.setState({ sortMetadata: sortMetadata });
     }
 
     changeUrl() {
@@ -267,7 +269,7 @@ export const GenomicViewComponent = withRouteData(
           result.gene.items.forEach(el => { el.checked = false; });
           result.consequence.items.forEach(el => { el.checked = false; });
           result.clinicalSignificance.items.forEach(el => { el.checked = false; });
-          this.setState({ filterMetadata: result, submittedFilterMetadata: { ...result} });
+          this.setState({ filterMetadata: result, submittedFilterMetadata: { ...result } });
           localStorage.setItem("originalFilterMetadata", JSON.stringify(result));
         }
       ).catch(e => {
@@ -365,7 +367,7 @@ export const GenomicViewComponent = withRouteData(
         sortMetadata: sortMetadata,
         filterMetadata: filterMetadata,
       };
-      
+
       genomicsApi()
         .searchVariants(searchRequest)
         .then((results) => {
@@ -423,18 +425,18 @@ export const GenomicViewComponent = withRouteData(
 
     handleFilterSubmit(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) {
       if (filteredMetadata['alleleFrequency']['checked']) {
-              filteredMetadata['alleleFrequency']['maxFreq'] = filteredMetadata['alleleFrequency']['max'];
-              filteredMetadata['alleleFrequency']['minFreq'] = filteredMetadata['alleleFrequency']['min'];
+        filteredMetadata['alleleFrequency']['maxFreq'] = filteredMetadata['alleleFrequency']['max'];
+        filteredMetadata['alleleFrequency']['minFreq'] = filteredMetadata['alleleFrequency']['min'];
       }
 
-      this.setState({submittedFilterMetadata: { ...filteredMetadata} });
+      this.setState({ submittedFilterMetadata: { ...filteredMetadata } });
       this.filterGenomics(filteredMetadata, sortMetadata);
       this.getSearchSize(this.state.searchTerm, true);
     }
 
     handleScrollBottom() {
-     
-      this.setState({ currentPage: this.state.currentPage + 1, loadingResults:true})
+
+      this.setState({ currentPage: this.state.currentPage + 1, loadingResults: true, scrollClean: false })
       const { searchTerm, currentPage, sortMetadata, rowCount, filterMetadata } = this.state;
 
       const searchRequest: SearchVariantsRequest = {
@@ -444,7 +446,7 @@ export const GenomicViewComponent = withRouteData(
         sortMetadata: sortMetadata,
         filterMetadata: filterMetadata,
       };
-      
+
       genomicsApi()
         .searchVariants(searchRequest)
         .then((results) => {
@@ -457,7 +459,8 @@ export const GenomicViewComponent = withRouteData(
 
     render() {
       const { currentPage, selectionId, loadingVariantListSize, variantListSize, loadingResults, searchResults,
-        participantCount, chartData, rowCount, searchTerm, filterMetadata, sortMetadata, submittedFilterMetadata } = this.state;
+        participantCount, chartData, rowCount, searchTerm, filterMetadata, sortMetadata, submittedFilterMetadata,
+        scrollClean } = this.state;
       return <React.Fragment>
         <style>{css}</style>
         <div style={styles.pageHeader}>
@@ -480,11 +483,11 @@ export const GenomicViewComponent = withRouteData(
             </div>
           </div>
           {selectionId === 1 && (
-          <div style={styles.headingLayout}>
-          <p style={styles.desc}>View the self-reported race/ethnicity, sex assigned at birth, and
-          age of participants whose genomic data are available within the
-          Researcher Workbench.{" "}</p>
-          </div>
+            <div style={styles.headingLayout}>
+              <p style={styles.desc}>View the self-reported race/ethnicity, sex assigned at birth, and
+                age of participants whose genomic data are available within the
+                Researcher Workbench.{" "}</p>
+            </div>
           )}
           <div style={styles.innerContainer} id="childView">
             {selectionId === 1 && (
@@ -511,7 +514,7 @@ export const GenomicViewComponent = withRouteData(
                 onFilterSubmit={(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) => {
                   this.handleFilterSubmit(filteredMetadata, sortMetadata);
                 }}
-                onScrollBottom = {()=>this.handleScrollBottom()}
+                onScrollBottom={() => this.handleScrollBottom()}
                 currentPage={currentPage}
                 rowCount={rowCount}
                 variantListSize={variantListSize}
@@ -523,6 +526,7 @@ export const GenomicViewComponent = withRouteData(
                 filterMetadata={filterMetadata}
                 submittedFilterMetadata={submittedFilterMetadata}
                 sortMetadata={sortMetadata}
+                scrollClean={scrollClean}
               />
             )}
 

--- a/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
@@ -435,10 +435,8 @@ export const GenomicViewComponent = withRouteData(
     }
 
     handleScrollBottom() {
-
       this.setState({ currentPage: this.state.currentPage + 1, loadingResults: true, scrollClean: false })
       const { searchTerm, currentPage, sortMetadata, rowCount, filterMetadata } = this.state;
-
       const searchRequest: SearchVariantsRequest = {
         query: searchTerm,
         pageNumber: currentPage,

--- a/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
@@ -290,7 +290,7 @@ export const GenomicViewComponent = withRouteData(
           null
         );
         this.setState(
-          { loadingResults: true, currentPage: 1, rowCount: 50 },
+          { loadingResults: true, currentPage: 1, rowCount: 100 },
           () => {
             this.fetchVariantData();
           }

--- a/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
@@ -290,7 +290,7 @@ export const GenomicViewComponent = withRouteData(
           null
         );
         this.setState(
-          { loadingResults: true, currentPage: 1, rowCount: 100 },
+          { loadingResults: true, currentPage: 1, rowCount: 200 },
           () => {
             this.fetchVariantData();
           }
@@ -380,10 +380,10 @@ export const GenomicViewComponent = withRouteData(
 
     filterGenomics(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) {
     // this.setState({loadingResults:false})
-      const { searchTerm, currentPage, rowCount } = this.state;
+      const { searchTerm, rowCount } = this.state;
       const searchRequest = {
         query: searchTerm,
-        pageNumber: currentPage,
+        pageNumber: 1,
         rowCount: rowCount,
         filterMetadata: filteredMetadata,
         sortMetadata: sortMetadata,

--- a/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
@@ -379,6 +379,7 @@ export const GenomicViewComponent = withRouteData(
     }
 
     filterGenomics(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) {
+    // this.setState({loadingResults:false})
       const { searchTerm, currentPage, rowCount } = this.state;
       const searchRequest = {
         query: searchTerm,
@@ -391,7 +392,7 @@ export const GenomicViewComponent = withRouteData(
       genomicsApi()
         .searchVariants(searchRequest)
         .then((results) => {
-          this.setState({ searchResults: results.items });
+          this.setState({ searchResults: results.items,loadingResults:false });
         });
     }
 

--- a/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
@@ -379,7 +379,6 @@ export const GenomicViewComponent = withRouteData(
     }
 
     filterGenomics(filteredMetadata: GenomicFilters, sortMetadata: SortMetadata) {
-    // this.setState({loadingResults:false})
       const { searchTerm, rowCount } = this.state;
       const searchRequest = {
         query: searchTerm,

--- a/public-ui/src/environments/test-env-base.ts
+++ b/public-ui/src/environments/test-env-base.ts
@@ -9,5 +9,5 @@ export const testEnvironmentBase = {
   geno: true,
   genoFilters: true,
   fitbitCDRUpdate: true,
-  infiniteSrcoll: false
+  infiniteSrcoll: true
 };

--- a/public-ui/src/styles.css
+++ b/public-ui/src/styles.css
@@ -762,7 +762,7 @@ strong {
 /* For Chrome */
 ::-webkit-scrollbar {
   width: 6px!important;
-  height: 6px!important;
+  height: 6px!important;z
 }
 
 ::-webkit-scrollbar-track {

--- a/public-ui/src/styles.css
+++ b/public-ui/src/styles.css
@@ -762,7 +762,7 @@ strong {
 /* For Chrome */
 ::-webkit-scrollbar {
   width: 6px!important;
-  height: 6px!important;z
+  height: 6px!important;
 }
 
 ::-webkit-scrollbar-track {


### PR DESCRIPTION
fixes and tweaks to genomic infinite scroll:

fixed: scrolling is held up when user reaches bottom of currently displayed rows and needs to wait as more rows need to load

fixed: potential fix = load more rows, earlier, to avoid pauses when scrolling to bottom of table

fixed: bug when filters/sorting applied when user is scrolled down onto subsequent pages

fixed: potential fix = when applying filters/sorting, automatically return to row 1 of page 1

fixed: Filter & Sort button intermittently disappears when new pages/rows are loading