### PR TITLE
[risk=no] [DB-1308] expanding tooltip width to fit in all the 7 characters after colon

### DIFF
--- a/public-ui/src/app/data-browser/views/genomic-view/components/population-chart.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/population-chart.component.tsx
@@ -95,7 +95,7 @@ export class PopulationChartReactComponent extends React.Component<
 
   getTooltipHelpText(name: string, percentage: any, count: number) {
     return (
-      '<div class="chart-tooltip" style="white-space: normal; word-wrap: break-word; font-size: 1.5em; width: 15em; color: #302C71;"' +
+      '<div class="chart-tooltip" style="white-space: normal; word-wrap: break-word; font-size: 1.5em; width: 16em; color: #302C71;"' +
       "<strong>" +
       name +
       "</strong> <br /> " +


### PR DESCRIPTION
![image](https://github.com/all-of-us/data-browser/assets/21062724/74caf5d0-e0b5-4800-b67f-f069f3636b4b)
