### PR TITLE
[risk=no][DB-1337]Add bold text styling to population title in genomic ring chart tooltip[DB-1338]Change "Percentage of Alleles" font color to #262262

### DIFF
--- a/public-ui/src/app/data-browser/views/genomic-view/components/population-chart.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/population-chart.component.tsx
@@ -37,7 +37,7 @@ export class PopulationChartReactComponent extends React.Component<
     const newBaseOptions = getBaseOptions();
     newBaseOptions.chart.type = "pie";
     newBaseOptions.title.text =
-      '<div style="text-align:center">PERCENTAGE <br/> OF ALLELES</div>';
+      '<div style=" color:#262262;text-align:center">PERCENTAGE <br/> OF ALLELES</div>';
     newBaseOptions.title.verticalAlign = "middle";
     newBaseOptions.title.style = {
       color: "black",
@@ -95,7 +95,7 @@ export class PopulationChartReactComponent extends React.Component<
 
   getTooltipHelpText(name: string, percentage: any, count: number) {
     return (
-      '<div class="chart-tooltip" style="white-space: normal; word-wrap: break-word; font-size: 1.5em; width: 18em; color: #302C71;"' +
+      '<div class="chart-tooltip" style="white-space: normal; word-wrap: break-word; font-size: 1.5em; width: 18em; color: #302C71;">' +
       "<strong>" +
       name +
       "</strong> <br /> " +

--- a/public-ui/src/styles.css
+++ b/public-ui/src/styles.css
@@ -791,7 +791,10 @@ a a:link a:visited {
   border:#262262 1px solid;
   box-shadow: 0px 0px 2px 1px #26226258;
 }
-
+.chart-tooltip strong{
+  font-family: 'GothamBold';
+  font-weight: bold;
+}
 .sources-tooltip {
   white-space: pre-line;
   min-width: 300px;


### PR DESCRIPTION
<img width="432" alt="image" src="https://github.com/all-of-us/data-browser/assets/860209/1f18cab1-8627-4112-a7a4-d3e4392be484">