### PR TITLE
[risk=no] display variant annotations as 2 rows of 4

### DIFF
--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-expanded.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-expanded.component.tsx
@@ -30,7 +30,7 @@ const css = `
 }
 .pop-table {
         display: grid;
-        grid-template-columns: 26% 18.5% 18.5% 18.5% 18.5%;
+        grid-template-columns: 26% 25% 25% 24%;
         font-size: 14px;
     }
 .pop-desc {
@@ -40,7 +40,7 @@ const css = `
 }
 .body {
     display: grid;
-    grid-template-columns: 26% 18.5% 18.5% 18.5% 18.5%;
+    grid-template-columns: 26% 25% 25% 24%;
     column-gap: 1rem;
     row-gap: 1rem;
     padding-top: 1rem;


### PR DESCRIPTION
![image](https://github.com/all-of-us/data-browser/assets/21062724/4bc05d62-0ce9-4350-88a6-750dade8bcb4)
