### PR TITLE
[risk=no][DB-1369]Center column header text in genomic variant card

### DIFF
--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-expanded.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-expanded.component.tsx
@@ -132,6 +132,7 @@ const styles = reactStyles({
     padding: ".5rem",
     paddingBottom: "0",
     paddingTop: "0",
+    textAlign: "center"
   },
   popTableBody: {
     borderBottom: "1px solid #DDE0E4",


### PR DESCRIPTION
<img width="808" alt="image" src="https://github.com/all-of-us/data-browser/assets/860209/d293bdfd-01a5-4b40-872a-49b1de7a67da">
