### PR TITLE
[risk=no] upgrading deploy node to 22 

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 
 RUN npm install --global yarn n
 # Upgrade to Node 16, above installs 10.
-RUN n 18
+RUN n 22
 
 # Install openapi-generator-cli
 RUN npm install @openapitools/openapi-generator-cli -g

--- a/public-ui/src/dev/server/Dockerfile
+++ b/public-ui/src/dev/server/Dockerfile
@@ -43,7 +43,7 @@ RUN apk --no-cache add openjdk8-jre
 
 RUN npm install --global --force yarn n
 
-Run n 18
+Run n 22
 
 # We touch yarn's config file here so that we can explicitly make sure
 # yarn has permission to read/write to it, even though its empty.


### PR DESCRIPTION
to fix this error on deploy [2/4] Fetching packages...
error minimatch@10.0.1: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.20.4"
error Found incompatible module.
