### PR TITLE
[risk=no] addressing sv vcf feedback 1

### DIFF
--- a/public-api/config/cdr_config_local.json
+++ b/public-api/config/cdr_config_local.json
@@ -7,7 +7,7 @@
     "bigqueryProject": "all-of-us-ehr-dev",
     "bigqueryDataset": "synthetic_cdr20180606",
     "genomicsProject": "aou-db-prod",
-    "genomicsDataset": "2022q4r6_genomics",
+    "genomicsDataset": "2024q3r2_genomics",
     "creationTime": "2017-12-26 00:00:00Z",
     "releaseNumber": 1,
     "numParticipants": 946237,

--- a/public-ui/src/app/app-routing.tsx
+++ b/public-ui/src/app/app-routing.tsx
@@ -107,10 +107,10 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
         path="/variants"
         component={() =>
           GenomicViewComponent({
-            selectionId: 2,
+            selectionId: 1,
             routeData: {
-              title: "Variants",
-              breadcrumb: { value: "Variants" },
+              title: "Genomic Variants",
+              breadcrumb: { value: "Genomic Variants" },
             },
           })
         }
@@ -119,10 +119,10 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
         path="/variants/:search"
         component={() =>
           GenomicViewComponent({
-            selectionId: 2,
+            selectionId: 1,
             routeData: {
-              title: "Variants",
-              breadcrumb: { value: "Variants" },
+              title: "Genomic Variants",
+              breadcrumb: { value: "Genomic Variants" },
             },
           })
         }
@@ -131,10 +131,10 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
         path="/structural-variants"
         component={() =>
           GenomicViewComponent({
-            selectionId: 4,
+            selectionId: 2,
             routeData: {
-              title: "Variants",
-              breadcrumb: { value: "Variants" },
+              title: "Genomic Variants",
+              breadcrumb: { value: "Genomic Variants" },
             },
           })
         }
@@ -143,10 +143,10 @@ export const AppRoutingComponent: React.FunctionComponent = () => {
         path="/structural-variants/:search"
         component={() =>
           GenomicViewComponent({
-            selectionId: 4,
+            selectionId: 2,
             routeData: {
-              title: "Variants",
-              breadcrumb: { value: "Variants" },
+              title: "Genomic Variants",
+              breadcrumb: { value: "Genomic Variants" },
             },
           })
         }

--- a/public-ui/src/app/data-browser/databrowser-routing.module.ts
+++ b/public-ui/src/app/data-browser/databrowser-routing.module.ts
@@ -82,9 +82,9 @@ const routes: Routes = [
             component: AppRouting,
             canActivate: [IsSafeGuard],
             data: {
-              title: "Variants",
+              title: "Genomic Variants",
               breadcrumb: {
-                value: "Variants",
+                value: "Genomic Variants",
               },
             },
           },
@@ -93,9 +93,9 @@ const routes: Routes = [
             component: AppRouting,
             canActivate: [IsSafeGuard],
             data: {
-              title: "Variants",
+              title: "Genomic Variants",
               breadcrumb: {
-                value: "Variants",
+                value: "Genomic Variants",
               },
             },
           },
@@ -104,9 +104,9 @@ const routes: Routes = [
             component: AppRouting,
             canActivate: [IsSafeGuard],
             data: {
-              title: "Variants",
+              title: "Genomic Variants",
               breadcrumb: {
-                value: "Variants",
+                value: "Genomic Variants",
               },
             },
           },
@@ -115,9 +115,9 @@ const routes: Routes = [
             component: AppRouting,
             canActivate: [IsSafeGuard],
             data: {
-              title: "Variants",
+              title: "Genomic Variants",
               breadcrumb: {
-                value: "Variants",
+                value: "Genomic Variants",
               },
             },
           },

--- a/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/genomic-view.component.tsx
@@ -300,15 +300,15 @@ export const GenomicViewComponent = withRouteData(
 
     topBarItems = [
       {
-        id: 2,
-        label: "Variant Search",
+        id: 1,
+        label: "SNV/Indel Variants",
       },
       {
-        id: 1,
+        id: 3,
         label: "Participant Demographics",
       },
       ...(this.svVCFBrowserFlag ? [{
-        id: 4,
+        id: 2,
         label: "Structural Variants",
       }] : [])
     ];
@@ -683,13 +683,13 @@ export const GenomicViewComponent = withRouteData(
       this.setState({
         selectionId: selected
       }, () => {
-        if (selected === 4) {
+        if (selected === 2) {
           // Change URL to Structural Variants path
           window.history.pushState({}, '', '/structural-variants');
-        } else if (selected === 2) {
+        } else if (selected === 1) {
           // Change URL to Variant Search path
           window.history.pushState({}, '', '/variants');
-        } else if (selected === 1) {
+        } else if (selected === 3) {
           // Change URL to Participant Demographics path
           window.history.pushState({}, '', '/participant-demographics');
         }
@@ -698,7 +698,7 @@ export const GenomicViewComponent = withRouteData(
 
 
     handleFaqClose() {
-      this.setState({ selectionId: 2 });
+      this.setState({ selectionId: 1 });
     }
 
     handleSearchTerm(searchTerm: string) {
@@ -732,10 +732,21 @@ export const GenomicViewComponent = withRouteData(
     componentDidMount() {
       window.addEventListener("beforeunload", this.componentCleanup);
       const { search } = urlParamsStore.getValue();
+      const currentUrl = window.location.href;
+      console.log(currentUrl);
+      console.log(currentUrl.includes('variants'));
+      console.log(currentUrl.includes('structural-variants'));
+
       if (search) {
-        this.setState({ searchTerm: search }, () => {
-          this.getVariantSearch(search);
-        });
+          if (currentUrl.includes('structural-variants')) {
+              this.setState({ svSearchTerm: search }, () => {
+                this.getSVVariantSearch(search);
+              });
+          } else if (currentUrl.includes('variants')) {
+              this.setState({ searchTerm: search }, () => {
+                this.getVariantSearch(search);
+              });
+          }
       }
       this.getGenomicParticipantCounts();
       this.getGenomicChartData();
@@ -837,14 +848,7 @@ export const GenomicViewComponent = withRouteData(
 
     getTitle() {
       const { selectionId } = this.state;
-      return selectionId === 4 ? "Structural Variants" : "SNV/Indel Variants";
-    }
-
-    getBreadcrumbTitle() {
-      const { selectionId } = this.state;
-      return selectionId === 4
-        ? "Structural Variants"
-        : "SNV/Indel Variants";
+      return "Genomic Variants";
     }
 
     render() {
@@ -871,6 +875,7 @@ export const GenomicViewComponent = withRouteData(
         submittedSVFilterMetadata,
         scrollClean,
       } = this.state;
+      this.topBarItems = this.topBarItems.sort((a, b) => a.id - b.id);
       return (
         <React.Fragment>
           <style>{css}</style>
@@ -907,7 +912,7 @@ export const GenomicViewComponent = withRouteData(
                 </div>
               </div>
             </div>
-            {selectionId === 1 && (
+            {selectionId === 3 && (
               <div style={styles.innerContainer}>
                 <p style={styles.desc}>
                   View the self-reported categories, sex assigned at birth, and
@@ -917,13 +922,13 @@ export const GenomicViewComponent = withRouteData(
               </div>
             )}
             <div style={styles.innerContainer} id="childView">
-              {selectionId === 1 && (
+              {selectionId === 3 && (
                 <GenomicOverviewComponent
                   participantCount={participantCount}
                   chartData={chartData}
                 />
               )}
-              {selectionId === 2 && (
+              {selectionId === 1 && (
                 <GenomicSearchComponent
                   onSearchInput={(searchWord: string) => {
                     this.handleSearchTerm(searchWord);
@@ -959,7 +964,7 @@ export const GenomicViewComponent = withRouteData(
                   scrollClean={scrollClean}
                 />
               )}
-              {selectionId === 4 && (
+              {selectionId === 2 && (
                 <SVGenomicSearchComponent
                   onSearchInput={(svSearchWord: string) => {
                     this.handleSVSearchTerm(svSearchWord);
@@ -996,7 +1001,7 @@ export const GenomicViewComponent = withRouteData(
                 />
               )}
 
-              {selectionId === 3 && (
+              {selectionId === 4 && (
                 <GenomicFaqComponent closed={() => this.handleFaqClose()} />
               )}
               <div style={styles.faqHeading}>
@@ -1004,7 +1009,7 @@ export const GenomicViewComponent = withRouteData(
                   Questions about genetic ancestry?
                   <span
                     style={styles.faqLink}
-                    onClick={() => this.topBarClick(3)}
+                    onClick={() => this.topBarClick(4)}
                   >
                     Learn More
                   </span>

--- a/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-search.component.tsx
@@ -221,7 +221,9 @@ export class SVVariantSearchComponent extends React.Component<Props, State> {
           </div>
           <div style={styles.searchHelpText}>
             Examples by query type: <br></br>
-            <strong>Variant:</strong> 1-104946932-0fa1 <br></br>
+            <strong>Gene:</strong> BRCA2 <br></br>
+            <strong>Variant:</strong> AoUSVPhaseI.chr1.final_cleanup_BND_chr1_1024 <br></br>
+            <strong>Genomic Region:</strong> chr13:32355000-42375000
           </div>
         </div>
         {submittedFilterMetadata && (

--- a/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-table.component.tsx
@@ -404,13 +404,27 @@ export class SVVariantTableComponent extends React.Component<Props, State> {
                   query:
                 </div>
                 <div style={styles.helpText}>
+                  <strong>Gene:</strong>{" "}
+                  <div
+                    onClick={() => this.searchItem("BRCA2")}
+                    style={styles.helpSearchDiv}
+                  >BRCA2</div>
+                </div>
+                <div style={styles.helpText}>
                   <strong>Variant:</strong>{" "}
                   <div
-                    onClick={() => this.searchItem("1-104946932-0fa1")}
+                    onClick={() => this.searchItem("AoUSVPhaseI.chr1.final_cleanup_BND_chr1_1024")}
                     style={styles.helpSearchDiv}
                   >
-                    1-104946932-0fa1
+                    AoUSVPhaseI.chr1.final_cleanup_BND_chr1_1024
                   </div>
+                </div>
+                <div style={styles.helpText}>
+                  <strong>Genomic region:</strong>{" "}
+                  <div
+                    onClick={() => this.searchItem("chr13:32355000-32375000")}
+                    style={styles.helpSearchDiv}
+                  >chr13:32355000-32375000</div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
1. “SV Variants” is redundant - “Structural Variants Variants”. Should just have “Structural Variants”
2. Top of page says “SNV/Indel Variants” even when on SVs tab
3. SVs tab should probably be next to variant search rather than after Participant demographics
4. Need more example query types - region, gene
5. Since we now have two variant types on that page, we need to change some titles also. In the screenshot - A and B should now be “Genomic Variants” and C should be “SNV/Indel Variants”
6. Currently on test, B changes to Structural Variants when that tab is selected, but we can keep B as Genomic Variants at all times regardless of which tab is selected
