### PR TITLE
[risk=no] [DB-1494] cleaning up age and sex charts

### DIFF
--- a/public-ui/src/app/data-browser/services/tooltip.service.ts
+++ b/public-ui/src/app/data-browser/services/tooltip.service.ts
@@ -247,7 +247,7 @@ export const tooltips = {
     "Values can also be reported in different units, " +
     "such as Fahrenheit or Celsius for body temperature.",
   sortVariants: `Click to select ascending or descending`,
-  Map: `This chart displays a distribution of residential locations self-reported in participants' records.`,
+  Location: `This chart displays a distribution of residential locations self-reported in participants' records.`,
   "ehrAgeSexChartHelpText": `This chart displays a binned distribution of the ages at which medical concepts first occurred in participants' electronic health records, stratified by participant sex.`,
   "surveyAgeSexChartHelpText": `This chart displays a binned distribution of the ages at which participants took the survey, stratified by participant sex.`,
 };

--- a/public-ui/src/app/data-browser/views/concept-chart/concept-chart-react.component.tsx
+++ b/public-ui/src/app/data-browser/views/concept-chart/concept-chart-react.component.tsx
@@ -158,13 +158,11 @@ export class ConceptChartReactComponent extends React.Component<Props, State> {
     this.state = {
       graphButtons:
         this.props.domain.name.toLowerCase() === "labs & measurements"
-          ? ["Values", "Sex", "Age", "Sources", ...(environment.heatmap ? ["Map"] : []),  ...(environment.combinedAgeGenderChart ? ["Age + Sex"] : [])]
+          ? ["Values", "Age + Sex", "Location", "Sources"]
           : [
-            "Sex",
-            "Age",
+            "Age + Sex",
+            "Location",
             "Sources",
-            ...(environment.heatmap ? ["Map"] : []),
-            ...(environment.combinedAgeGenderChart ? ["Age + Sex"] : []),
           ],
       graphToShow: this.props.graphToShow
         ? this.props.graphToShow
@@ -298,7 +296,7 @@ export class ConceptChartReactComponent extends React.Component<Props, State> {
         measurementGenderCountAnalysis =
           conceptAnalyses.measurementGenderCountAnalysis;
         break;
-      case GraphType.map:
+      case GraphType.location:
         selectedAnalysis = conceptAnalyses.locationAnalysis;
         break;
       case GraphType.ageGenderStacked:
@@ -587,12 +585,13 @@ export class ConceptChartReactComponent extends React.Component<Props, State> {
                   selectedResult=""
                 />
               </div>
-            ) : graphToShow === "Map" ? (
+            ) : graphToShow === "Location" ? (
               <div className="chart" key="map-chart">
                 <HeatMapReactComponent
                   locationAnalysis={selectedChartAnalysis}
                   domain={"ehr"}
-                  selectedResult = "" />
+                  selectedResult = ""
+                  color = "" />
               </div>
             ) : graphToShow === "Age + Sex" ? (
               <div className="chart" key="age-gender-stacked-chart">

--- a/public-ui/src/app/data-browser/views/fitbit-view/fitbit-view-react.component.tsx
+++ b/public-ui/src/app/data-browser/views/fitbit-view/fitbit-view-react.component.tsx
@@ -304,62 +304,8 @@ export const FitbitReactComponent = withRouteData(
                 </div>
                 <div className="fm-body" style={styles.fmBody}>
                   <h2 style={styles.selectedDisplayH}>{selectedDisplay} </h2>
-                  <div className="fm-body-top" style={styles.fmBodyTop}>
-                    <div className="fm-chart" style={styles.fmChart}>
-                      <div
-                        className="display-body"
-                        style={styles.chartDisplayBody}
-                      >
-                        Participants over time
-                      </div>
-                      {selectedAnalyses && totalCountAnalysis && (
-                        <ChartFitbitReactComponent
-                          concepts={selectedAnalyses.participantCountAnalysis}
-                          countAnalysis={totalCountAnalysis}
-                        />
-                      )}
-                    </div>
-                    <div className="fm-chart" style={styles.fmChart}>
-                      <div
-                        className="display-body"
-                        style={styles.chartDisplayBody}
-                      >
-                        Sex
-                      </div>
-                      {selectedAnalyses &&
-                        totalCountAnalysis &&
-                        domainCountAnalysis && (
-                          <BioSexChartReactComponent
-                            genderAnalysis={selectedAnalyses.genderAnalysis}
-                            genderCountAnalysis={
-                              domainCountAnalysis.genderCountAnalysis
-                            }
-                            domain="fitbit"
-                            selectedResult={selectedResult}
-                          />
-                        )}
-                    </div>
-                  </div>
+
                   <div className="fm-body-bottom" style={styles.fmBodyBottom}>
-                    <div className="fm-chart" style={styles.fmBottomChart}>
-                      <div
-                        className="display-body"
-                        style={styles.chartDisplayBody}
-                      >
-                        Age at data collection
-                      </div>
-                      {selectedAnalyses && domainCountAnalysis && (
-                        <AgeChartReactComponent
-                          ageAnalysis={selectedAnalyses.ageAnalysis}
-                          ageCountAnalysis={
-                            domainCountAnalysis.ageCountAnalysis
-                          }
-                          domain="fitbit"
-                          selectedResult={selectedResult}
-                        />
-                      )}
-                    </div>
-                    {environment.combinedAgeGenderChart && (
                       <div className="fm-chart" style={styles.fmBottomChart}>
                         <div className="display-body" style={styles.chartDisplayBody}>
                           Age + Sex
@@ -372,20 +318,18 @@ export const FitbitReactComponent = withRouteData(
                           />
                         )}
                       </div>
-                    )}
-                    {environment.heatmap && (
                     <div className="fm-chart" style={styles.fmBottomChart}>
                       <div className="display-body" style={styles.chartDisplayBody}>
-                        Location of data collection
+                        Location
                       </div>
                       {selectedAnalyses && selectedAnalyses.locationAnalysis && (
                         <HeatMapReactComponent
                           locationAnalysis={selectedAnalyses?.locationAnalysis}
                           domain="fitbit"
-                          selectedResult = "" />
+                          selectedResult = ""
+                          color = "" />
                       )}
                     </div>
-                    )}
                   </div>
                 </div>
               </div>

--- a/public-ui/src/app/data-browser/views/genomic-view/components/genomic-chart.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/genomic-chart.component.tsx
@@ -139,7 +139,7 @@ export class GenomicChartComponent extends React.Component<Props, State> {
 
       chartOptions.series = [
         { name: "Male", data: maleSeries, color: "#1F78B4" },
-        { name: "Female", data: femaleSeries, color: "#A27BD7" },
+        { name: "Female", data: femaleSeries, color: this.props.color },
         { name: "Other", data: otherSeries, color: "#B2AEAD" },
       ];
 
@@ -265,10 +265,6 @@ export class GenomicChartComponent extends React.Component<Props, State> {
       <div style={styles.chartContainer}>
         <div style={styles.legendLayout}>
           <h3 style={styles.chartTitle}>{title}</h3>
-          <div style={styles.legend}>
-            <FontAwesomeIcon icon={faCircle} style={{ color: color }} />
-            <span style={styles.legendItem}>{legendText}</span>
-          </div>
         </div>
         {options && (
           <HighchartsReact

--- a/public-ui/src/app/data-browser/views/genomic-view/components/genomic-overview.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/genomic-overview.component.tsx
@@ -23,7 +23,7 @@ input[type='radio']{
 }
 input:focus{
   outline:none;
-  
+
 }
 input[type='radio']:before {
   content: '';
@@ -355,39 +355,22 @@ export class GenomicOverviewComponent extends React.Component<Props, State> {
                 selectedGenotype={selectedGenotype}
                 color={color}
               />
-              <GenomicChartComponent
-                counts={participantCounts[0]}
-                title="Sex"
-                data={sexAtBirthData}
-                selectedGenotype={selectedGenotype}
-                color={color}
-              />
-              <GenomicChartComponent
-                counts={participantCounts[0]}
-                title="Current age"
-                data={currentAgeData}
-                selectedGenotype={selectedGenotype}
-                color={color}
-              />
-              {environment.combinedAgeGenderChart && (
                   <GenomicChartComponent
                     counts={participantCounts[0]}
-                    title="Combined age + sex"
+                    title="Age + Sex"
                     data={combinedAgeSexData}
                     selectedGenotype={selectedGenotype}
                     color={color}
                   />
-              )}
-              {environment.heatmap && (
               <div style={styles.chartContainer}>
-                <h3 style={styles.chartTitle}>Genomic Variant Locations</h3>
+                <h3 style={styles.chartTitle}>Location</h3>
                 <HeatMapReactComponent
                   locationAnalysis={locationData}
                   domain="genomic"
                   selectedResult = ""
+                  color={color}
                 />
               </div>
-              )}
             </React.Fragment>
           )}
         </div>

--- a/public-ui/src/app/data-browser/views/survey-chart/survey-chart-react.component.tsx
+++ b/public-ui/src/app/data-browser/views/survey-chart/survey-chart-react.component.tsx
@@ -133,7 +133,7 @@ export class SurveyChartReactComponent extends React.Component<Props, State> {
       case GraphType.ageGenderStacked:
         selectedAnalysis = question.combinedAgeSexAnalysis;
         break;
-      case GraphType.map:
+      case GraphType.location:
         selectedAnalysis = question.locationAnalysis;
         break;
       default:
@@ -280,6 +280,7 @@ export class SurveyChartReactComponent extends React.Component<Props, State> {
               selectedResult={selectedResult}
               locationAnalysis={selectedChartAnalysis}
               domain={"survey"}
+              color = ""
             />
           </div>
         ) : isLoaded && selectedChartAnalysis.analysisId === 3115 ? (

--- a/public-ui/src/app/data-browser/views/survey-view/components/survey-answer-react.component.tsx
+++ b/public-ui/src/app/data-browser/views/survey-view/components/survey-answer-react.component.tsx
@@ -349,16 +349,7 @@ const SurveyAnswerRowComponent = class extends React.Component<
       surveyConceptId,
     } = this.props;
     const { drawerOpen, subQuestions, drawerLoading } = this.state;
-    const graphButtons = ["Sex", "Age When Survey Was Taken"];
-    if (isCopeSurvey) {
-      graphButtons.unshift("Survey Versions");
-    }
-    if (environment.heatmap)  {
-      graphButtons.push("Map");
-    }
-    if (environment.combinedAgeGenderChart)  {
-      graphButtons.push("Age + Sex");
-    }
+    const graphButtons = ["Age + Sex", "Location"];
     const participantPercentage = (
       (this.props.countValue / this.props.participantCount) *
       100

--- a/public-ui/src/app/utils/enum-defs.ts
+++ b/public-ui/src/app/utils/enum-defs.ts
@@ -8,7 +8,7 @@ export enum GraphType {
   Sources = "Sources",
   Values = "Values",
   None = "",
-  map = "Map",
+  location = "Location",
   ageGenderStacked = "Age + Sex",
 }
 


### PR DESCRIPTION
Cleaning up individual age and sex charts.

Changes: 

In the genomics participant demographics section
remove the key in the upper right corner of all the charts (ex. “short-read WGS”)
for the age+sex chart, change the purple color (female) to the same color used in the other charts for short-read, long-read, SV, and arrays?
for the map, change the purple hover color to the same color used in the other charts
change titles “Combined age + sex+ >> “Age + Sex” and “Genomic Variant Locations” >> “Location”
For all other sections, please change “Map” to “Location”
Remove the standalone age and sex charts and order the new charts like this
EHR: Age + Sex, Location, Sources (except keep Values first for L&M)
Genomics: Categories, Age + Sex, Location
Fitbit: Age + Sex, Location (remove participants over time)
Surveys: Age + Sex, Location