### PR TITLE
[risk=no] [DB-1521] changed the order of consequence using the order in the list for SV variants

### DIFF
--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/GenomicsController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/GenomicsController.java
@@ -103,19 +103,51 @@ public class GenomicsController implements GenomicsApiDelegate {
         CONSEQUENCE_SEVERITY_RANKS = Collections.unmodifiableMap(map);
     }
 
+    private static final Map<String, Integer> SV_CONSEQUENCE_SEVERITY_RANKS;
+    static {
+        Map<String, Integer> map = new HashMap<>();
+        map.put("LOF", 16);
+        map.put("COPY_GAIN", 15);
+        map.put("INTRAGENIC_EXON_DUP", 14);
+        map.put("PARTIAL_EXON_DUP", 13);
+        map.put("TSS_DUP", 12);
+        map.put("DUP_PARTIAL", 11);
+        map.put("INV_SPAN", 10);
+        map.put("MSV_EXON_OVERLAP", 9);
+        map.put("UTR", 8);
+        map.put("INTRONIC", 7);
+        map.put("BREAKEND_EXONIC", 6);
+        map.put("PROMOTER", 5);
+        map.put("INTERGENIC", 4);
+        map.put("NEAREST_TSS", 3);
+        map.put("NONCODING_SPAN", 2);
+        map.put("NONCODING_BREAKPOINT", 1);
+        SV_CONSEQUENCE_SEVERITY_RANKS = Collections.unmodifiableMap(map);
+    }
+
+    private static String buildSVConsequenceSeverityOrderBy(boolean ascending) {
+        StringBuilder caseStatement = new StringBuilder();
+        for (Map.Entry<String, Integer> entry : SV_CONSEQUENCE_SEVERITY_RANKS.entrySet()) {
+            caseStatement.append("WHEN TRIM(con) = '").append(entry.getKey()).append("' THEN ").append(entry.getValue()).append(" ");
+        }
+
+        String direction = ascending ? "ASC" : "DESC";
+        return " ORDER BY (SELECT MAX(CASE " + caseStatement.toString() + "ELSE 0 END) FROM UNNEST(SPLIT(consequence, ', ')) con) " + direction;
+    }
+
     private static final String CONSEQ_ORDER_BY_FOR_FILTERS =
             " ORDER BY " + getConsequenceSeverityCaseStatement("conseq") + " DESC";
 
     private static String buildConsequenceSeverityOrderBy(boolean ascending) {
         StringBuilder caseStatement = new StringBuilder();
         for (Map.Entry<String, Integer> entry : CONSEQUENCE_SEVERITY_RANKS.entrySet()) {
-            caseStatement.append("WHEN d = '").append(entry.getKey()).append("' THEN ").append(entry.getValue()).append(" ");
+            caseStatement.append("WHEN TRIM(d) = '").append(entry.getKey()).append("' THEN ").append(entry.getValue()).append(" ");
         }
 
-        // ascending=true means "least to most severe" → DESC order by rank (42 to 1)
-        // ascending=false means "most to least severe" → ASC order by rank (1 to 42)
+        // ascending=true means "least to most severe" → ASC order by rank (1 to 42)
+        // ascending=false means "most to least severe" → DESC order by rank (42 to 1)
         String direction = ascending ? "ASC" : "DESC";
-        return " ORDER BY (SELECT MIN(CASE " + caseStatement.toString() + "ELSE 999 END) FROM UNNEST(consequence) d) " + direction;
+        return " ORDER BY (SELECT MAX(CASE " + caseStatement.toString() + "ELSE 0 END) FROM UNNEST(consequence) d) " + direction;
     }
 
     private static final String genomicRegionRegex = "(?i)([\"]*)(chr([0-9]{1,})*[XYxy]*:{0,}).*";
@@ -296,7 +328,7 @@ public class GenomicsController implements GenomicsApiDelegate {
                     .append(entry.getKey()).append("' THEN ")
                     .append(entry.getValue()).append(" ");
         }
-        caseStatement.append("ELSE 999 END");
+        caseStatement.append("ELSE 0 END");
         return caseStatement.toString();
     }
 
@@ -755,11 +787,8 @@ public class GenomicsController implements GenomicsApiDelegate {
 
             SortColumnDetails consequenceColumnSortMetadata = sortMetadata.getConsequence();
             if (consequenceColumnSortMetadata != null && consequenceColumnSortMetadata.isSortActive()) {
-                if (consequenceColumnSortMetadata.getSortDirection().equals("desc")) {
-                    ORDER_BY_CLAUSE = " ORDER BY consequence DESC";
-                } else {
-                    ORDER_BY_CLAUSE = " ORDER BY consequence ASC";
-                }
+                boolean ascending = consequenceColumnSortMetadata.getSortDirection().equals("asc");
+                ORDER_BY_CLAUSE = buildSVConsequenceSeverityOrderBy(ascending);
             }
 
             SortColumnDetails positionColumnSortMetadata = sortMetadata.getPosition();
@@ -996,6 +1025,7 @@ public class GenomicsController implements GenomicsApiDelegate {
         System.out.println("*************************************************************");
         System.out.println(finalSql);
         System.out.println("*************************************************************");
+
 
         QueryJobConfiguration qjc = QueryJobConfiguration.newBuilder(finalSql)
                 .addNamedParameter("variant_id", QueryParameterValue.string(variant_id))
@@ -1300,6 +1330,10 @@ public class GenomicsController implements GenomicsApiDelegate {
         }
         finalSql += ORDER_BY_CLAUSE;
         finalSql += " LIMIT " + rowCount + " OFFSET " + ((Optional.ofNullable(page).orElse(1)-1)*rowCount);
+
+        System.out.println("*************************************************************");
+        System.out.println(finalSql);
+        System.out.println("*************************************************************");
         
 
         QueryJobConfiguration qjc = QueryJobConfiguration.newBuilder(finalSql)
@@ -1661,6 +1695,12 @@ public class GenomicsController implements GenomicsApiDelegate {
 
         geneFilterList.setItems(geneFilters);
         geneFilterList.setFilterActive(false);
+
+        conFilters.sort((a, b) -> {
+            int rankA = SV_CONSEQUENCE_SEVERITY_RANKS.getOrDefault(a.getOption(), 0);
+            int rankB = SV_CONSEQUENCE_SEVERITY_RANKS.getOrDefault(b.getOption(), 0);
+            return Integer.compare(rankA, rankB);
+        });
 
         conFilterList.setItems(conFilters);
         conFilterList.setFilterActive(false);

--- a/public-api/src/main/java/org/pmiops/workbench/publicapi/GenomicsController.java
+++ b/public-api/src/main/java/org/pmiops/workbench/publicapi/GenomicsController.java
@@ -1022,11 +1022,6 @@ public class GenomicsController implements GenomicsApiDelegate {
         finalSql += ORDER_BY_CLAUSE;
         finalSql += " LIMIT " + rowCount + " OFFSET " + ((Optional.ofNullable(page).orElse(1)-1)*rowCount);
 
-        System.out.println("*************************************************************");
-        System.out.println(finalSql);
-        System.out.println("*************************************************************");
-
-
         QueryJobConfiguration qjc = QueryJobConfiguration.newBuilder(finalSql)
                 .addNamedParameter("variant_id", QueryParameterValue.string(variant_id))
                 .addNamedParameter("genes", QueryParameterValue.string(genes))
@@ -1330,11 +1325,6 @@ public class GenomicsController implements GenomicsApiDelegate {
         }
         finalSql += ORDER_BY_CLAUSE;
         finalSql += " LIMIT " + rowCount + " OFFSET " + ((Optional.ofNullable(page).orElse(1)-1)*rowCount);
-
-        System.out.println("*************************************************************");
-        System.out.println(finalSql);
-        System.out.println("*************************************************************");
-        
 
         QueryJobConfiguration qjc = QueryJobConfiguration.newBuilder(finalSql)
                 .addNamedParameter("contig", QueryParameterValue.string(contig))

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-filter.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-filter.component.tsx
@@ -188,15 +188,6 @@ export class VariantFilterComponent extends React.Component<Props, State> {
                 );
               }
             })}
-            <div style={styles.sortByContainer}>
-              {
-                <VariantSortItemComponent
-                  cleared={cleared}
-                  onSortChange={(e) => this.handleSortChange(e)}
-                  sortMetadata={sortMetadata}
-                />
-              }
-            </div>
           </div>
           <div style={styles.actionBtnContainer}>
             <button onClick={() => this.handleClear()} style={styles.clearBtn}>

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -258,13 +258,13 @@ export class VariantSearchComponent extends React.Component<Props, State> {
           variantListSize > 0 &&
           environment.genoFilters ? (
             <div onClick={() => this.showFilter()} style={styles.filterBtn}>
-              <ClrIcon shape="filter-2" /> Filter & Sort
+              <ClrIcon shape="filter-2" /> Filter
             </div>
           ) : scrollClean ? (
             <div> </div>
           ) : (
             <div onClick={() => this.showFilter()} style={styles.filterBtn}>
-              <ClrIcon shape="filter-2" /> Filter & Sort
+              <ClrIcon shape="filter-2" /> Filter
             </div>
           )}
           <React.Fragment>

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-sort-item.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-sort-item.component.tsx
@@ -9,52 +9,6 @@ import { ClrIcon } from "app/utils/clr-icon";
 import { SortMetadata } from "publicGenerated/fetch";
 
 const styles = reactStyles({
-  sortItem: {
-    width: "100%",
-    paddingLeft: ".5rem",
-    fontSize: "0.8em",
-    display: "flex",
-    justifyContent: "space-between",
-    alignItems: "center",
-    color: "#262262",
-    letterSpacing: 0,
-    lineHeight: "16px",
-    cursor: "pointer",
-  },
-  sortItemClosed: {
-    transform: "rotate(90deg)",
-  },
-  sortItemOpen: {
-    transform: "rotate(180deg)",
-  },
-  sortItemForm: {
-    fontSize: "0.8em",
-    display: "flex",
-    overflow: "visible",
-    flexDirection: "column",
-    paddingLeft: "1rem",
-    paddingTop: ".25rem",
-  },
-  sortItemOption: {
-    fontSize: ".8em",
-    display: "flex",
-  },
-  sortItemCheck: {
-    marginRight: ".25rem",
-    height: ".8rem",
-    width: ".8rem",
-    marginTop: "0.1rem",
-  },
-  sortItemLabel: {
-    width: "80%",
-    whiteSpace: "nowrap",
-    textOverflow: "ellipsis",
-    overflow: "hidden",
-    // wordWrap: "break-word",
-  },
-  activeSort: {
-    fontFamily: "gothamBold",
-  },
 });
 
 const css = `
@@ -91,16 +45,6 @@ const css = `
 }
 `;
 
-const lables = {
-  gene: "Gene",
-  consequence: "Consequence",
-  variantType: "Variant Type",
-  clinicalSignificance: "ClinVar Significance",
-  alleleNumber: "Allele Number",
-  alleleFrequency: "Allele Frequency",
-  alleleCount: "Allele Count",
-};
-
 interface Props {
   cleared: Boolean;
   onSortChange: Function;
@@ -108,30 +52,16 @@ interface Props {
 }
 
 interface State {
-  sortItemOpen: Boolean;
   sortMetadata: SortMetadata;
   filterCats: any[];
-  sortCats: any[];
 }
 
 export class VariantSortItemComponent extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      sortItemOpen: false,
       sortMetadata: props.sortMetadata,
       filterCats: [
-        { display: "Gene", field: "gene" },
-        { display: "Consequence", field: "consequence" },
-        { display: "Variant Type", field: "variantType" },
-        { display: "ClinVar Significance", field: "clinicalSignificance" },
-        { display: "Allele Count", field: "alleleCount" },
-        { display: "Allele Number", field: "alleleNumber" },
-        { display: "Allele Frequency", field: "alleleFrequency" },
-        { display: "Homozygote Count", field: "homozygoteCount" },
-      ],
-      sortCats: [
-        { display: "Variant ID", field: "variantId" },
         { display: "Gene", field: "gene" },
         { display: "Consequence", field: "consequence" },
         { display: "Variant Type", field: "variantType" },
@@ -146,112 +76,7 @@ export class VariantSortItemComponent extends React.Component<Props, State> {
 
   componentDidMount(): void {}
 
-  sortClick() {
-    this.setState({ sortItemOpen: !this.state.sortItemOpen });
-  }
-
-  clickToSort(field) {
-    const { sortMetadata } = this.state;
-
-    if (sortMetadata[field].sortActive) {
-      if (sortMetadata[field].sortDirection === "asc") {
-        sortMetadata[field].sortDirection = "desc";
-      } else {
-        sortMetadata[field].sortDirection = "asc";
-      }
-      for (const item in sortMetadata) {
-        if (item !== field) {
-          sortMetadata[item].sortActive = false;
-          sortMetadata[item].sortDirection = "desc";
-        }
-      }
-    } else {
-      sortMetadata[field].sortActive = true;
-      for (const item in sortMetadata) {
-        if (item !== field) {
-          sortMetadata[item].sortActive = false;
-          sortMetadata[item].sortDirection = "asc";
-        }
-      }
-    }
-    this.setState({ sortMetadata: this.state.sortMetadata });
-  }
-
   render(): React.ReactNode {
-    const { cleared } = this.props;
-    const { sortItemOpen, sortMetadata, filterCats, sortCats } = this.state;
-
-    return (
-      <React.Fragment>
-        <style>{css}</style>
-        <div onClick={() => this.sortClick()} style={styles.sortItem}>
-          <span style={{ fontFamily: "gothamBold" }}>Sort By</span>
-          <div>
-            <ClrIcon
-              style={
-                !sortItemOpen
-                  ? { ...styles.sortItemClosed }
-                  : { ...styles.sortItemOpen }
-              }
-              shape="angle"
-            />
-          </div>
-        </div>
-        {cleared && sortItemOpen && (
-          <div style={styles.sortItemForm}>
-            {sortCats &&
-              sortCats.map((cat, index) => {
-                return (
-                  <div
-                    style={{ cursor: "pointer", position: "relative" }}
-                    key={index}
-                    onClick={(e) => this.clickToSort(cat.field)}
-                  >
-                    <span
-                      style={
-                        sortMetadata[cat.field].sortActive
-                          ? styles.activeSort
-                          : {}
-                      }
-                    >
-                      <div className="tooltip">
-                        {cat.display}
-                        <span className="tooltiptext">
-                          Click to select <br />
-                          ascending or descending
-                        </span>
-                      </div>
-                      {sortMetadata[cat.field].sortActive &&
-                        sortMetadata[cat.field].sortDirection === "asc" && (
-                          <FontAwesomeIcon
-                            icon={faArrowUp}
-                            aria-hidden="true"
-                            style={{
-                              color: "rgb(33, 111, 180)",
-                              marginLeft: "0.5em",
-                              cursor: "pointer",
-                            }}
-                          />
-                        )}
-                      {sortMetadata[cat.field].sortActive &&
-                        sortMetadata[cat.field].sortDirection === "desc" && (
-                          <FontAwesomeIcon
-                            icon={faArrowDown}
-                            aria-hidden="true"
-                            style={{
-                              color: "rgb(33, 111, 180)",
-                              marginLeft: "0.5em",
-                              cursor: "pointer",
-                            }}
-                          />
-                        )}
-                    </span>
-                  </div>
-                );
-              })}
-          </div>
-        )}
-      </React.Fragment>
-    );
+    return <React.Fragment></React.Fragment>;
   }
 }

--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-table.component.tsx
@@ -39,9 +39,11 @@ const styles = reactStyles({
     paddingTop: ".5rem",
     paddingBottom: ".5rem",
     paddingLeft: ".75rem",
+    cursor: "pointer",
+    position: "relative",
+    userSelect: "none",
   },
   headingLabel: {
-    borderBottom: "1px dashed",
   },
   first: {
     paddingLeft: ".5rem",
@@ -106,26 +108,26 @@ const css = `
         width: 72rem;
     }
 }
+.paginator {
+    background: #f9f9fa;
+    border-bottom: 1px solid #CCCCCC;
+    border-right: 1px solid #CCCCCC;
+    border-left: 1px solid #CCCCCC;
+    border-top: none;
+    border-radius: 0 0 3px 3px;
+    display: flex;
+    flex-direction: row;
+    gap: 2em;
+    justify-content: space-between;
+}
+@media (max-width: 600px) {
     .paginator {
-        background: #f9f9fa;
-        border-bottom: 1px solid #CCCCCC;
-        border-right: 1px solid #CCCCCC;
-        border-left: 1px solid #CCCCCC;
-        border-top: none;
-        border-radius: 0 0 3px 3px;
-        display: flex;
-        flex-direction: row;
-        gap: 2em;
-        justify-content: space-between;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: flex-start;
+        gap: 0;
     }
-    @media (max-width: 600px) {
-        .paginator {
-            flex-direction: column;
-            align-items: flex-start;
-            justify-content: flex-start;
-            gap: 0;
-        }
-    }
+}
 `;
 
 interface Props {
@@ -154,19 +156,8 @@ interface State {
 }
 
 export class VariantTableComponent extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      loading: props.loadingResults,
-      searchResults: props.searchResults,
-      sortMetadata: props.sortMetadata,
-      allowParentScroll: true,
-    };
-  }
   scrollAreaRef: React.RefObject<HTMLDivElement> = React.createRef();
-
   observer = null;
-
   columnNames = [
     "Variant ID",
     "Gene",
@@ -179,6 +170,16 @@ export class VariantTableComponent extends React.Component<Props, State> {
     "Homozygote Count",
   ];
   debounceTimer = null;
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      loading: props.loadingResults,
+      searchResults: props.searchResults,
+      sortMetadata: props.sortMetadata,
+      allowParentScroll: true,
+    };
+  }
 
   componentDidUpdate(prevProps: Readonly<Props>) {
     const { searchResults, loadingResults, filtered } = this.props;
@@ -198,14 +199,11 @@ export class VariantTableComponent extends React.Component<Props, State> {
       if (scrollArea) {
         const scrollTop = scrollArea.scrollTop;
         const scrollHeight = scrollArea.scrollHeight;
-        // trigger scroll at 35%
         const scrolledToBottom = scrollTop / scrollHeight > 0.35;
         if (
           scrolledToBottom &&
-          this.props.currentPage <
-            this.props.variantListSize / this.props.rowCount
+          this.props.currentPage < this.props.variantListSize / this.props.rowCount
         ) {
-          // Fetch new data and append
           this.props.onScrollBottom();
         }
       }
@@ -248,7 +246,6 @@ export class VariantTableComponent extends React.Component<Props, State> {
     this.props.onSearchTerm(searchTerm);
   }
 
-  // Function to scroll the div with class 'scroll-area' to the top
   scrollAreaToTop = () => {
     if (this.scrollAreaRef.current) {
       this.scrollAreaRef.current.scrollTop = 0;
@@ -257,10 +254,28 @@ export class VariantTableComponent extends React.Component<Props, State> {
 
   setArrowIcon(varName: string) {
     const { sortMetadata } = this.state;
-    return sortMetadata[varName].sortDirection === "asc"
-      ? faArrowUp
-      : faArrowDown;
+    return sortMetadata[varName].sortDirection === "asc" ? faArrowUp : faArrowDown;
   }
+
+  renderColumnHeader = (columnKey: string, displayName: string, additionalStyles = {}) => {
+    const { sortMetadata } = this.state;
+    return (
+      <div
+        className="heading-item"
+        style={{ ...styles.headingItem, ...additionalStyles }}
+        onClick={() => this.sortClick(columnKey)}
+        title = "Click to sort"
+      >
+        <span style={styles.headingLabel}>{displayName}</span>
+        {sortMetadata[columnKey].sortActive && (
+          <FontAwesomeIcon
+            icon={this.setArrowIcon(columnKey)}
+            style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
+          />
+        )}
+      </div>
+    );
+  };
 
   render() {
     const {
@@ -270,8 +285,7 @@ export class VariantTableComponent extends React.Component<Props, State> {
       rowCount,
       currentPage,
     } = this.props;
-    const { loading, searchResults, sortMetadata, allowParentScroll } =
-      this.state;
+    const { loading, searchResults, allowParentScroll } = this.state;
     styles.noScroll.overflowX = !allowParentScroll ? "hidden" : "scroll";
 
     return (
@@ -288,92 +302,15 @@ export class VariantTableComponent extends React.Component<Props, State> {
             style={{ ...styles.tableContainer, ...styles.noScroll }}
           >
             <div className="header-layout">
-              <div style={{ ...styles.headingItem, ...styles.first }}>
-                <span style={styles.headingLabel}>Variant ID</span>
-                {sortMetadata.variantId.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("variantId")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
-              <div style={styles.headingItem}>
-                <span style={styles.headingLabel}>Gene</span>
-                {sortMetadata.gene.sortActive && (
-                  <React.Fragment>
-                    <FontAwesomeIcon
-                      icon={this.setArrowIcon("gene")}
-                      style={{
-                        color: "rgb(33, 111, 180)",
-                        marginLeft: "0.5em",
-                      }}
-                    />
-                  </React.Fragment>
-                )}
-              </div>
-              <div style={styles.headingItem}>
-                <span style={styles.headingLabel}>Consequence</span>
-                {sortMetadata.consequence.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("consequence")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
-              <div style={styles.headingItem}>
-                <span style={styles.headingLabel}>Variant Type</span>
-                {sortMetadata.variantType.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("variantType")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
-              <div style={styles.headingItem}>
-                <span style={styles.headingLabel}>ClinVar Significance</span>
-                {sortMetadata.clinicalSignificance.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("clinicalSignificance")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
-              <div style={styles.headingItem}>
-                <span style={styles.headingLabel}>Allele Count</span>
-                {sortMetadata.alleleCount.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("alleleCount")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
-              <div style={styles.headingItem}>
-                <span style={styles.headingLabel}>Allele Number</span>
-                {sortMetadata.alleleNumber.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("alleleNumber")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
-              <div style={styles.headingItem}>
-                <span style={styles.headingLabel}>Allele Frequency</span>
-                {sortMetadata.alleleFrequency.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("alleleFrequency")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
-              <div style={{ ...styles.headingItem, ...styles.last }}>
-                <span style={styles.headingLabel}>Homozygote Count</span>
-                {sortMetadata.homozygoteCount.sortActive && (
-                  <FontAwesomeIcon
-                    icon={this.setArrowIcon("homozygoteCount")}
-                    style={{ color: "rgb(33, 111, 180)", marginLeft: "0.5em" }}
-                  />
-                )}
-              </div>
+              {this.renderColumnHeader("variantId", "Variant ID", styles.first)}
+              {this.renderColumnHeader("gene", "Gene")}
+              {this.renderColumnHeader("consequence", "Consequence")}
+              {this.renderColumnHeader("variantType", "Variant Type")}
+              {this.renderColumnHeader("clinicalSignificance", "ClinVar Significance")}
+              {this.renderColumnHeader("alleleCount", "Allele Count")}
+              {this.renderColumnHeader("alleleNumber", "Allele Number")}
+              {this.renderColumnHeader("alleleFrequency", "Allele Frequency")}
+              {this.renderColumnHeader("homozygoteCount", "Homozygote Count", styles.last)}
             </div>
 
             {searchResults &&
@@ -403,7 +340,7 @@ export class VariantTableComponent extends React.Component<Props, State> {
           <div style={styles.tableFrame}>
             {(loading || loadingVariantListSize || loadingResults) && (
               <div style={styles.center}>
-                <Spinner />{" "}
+                <Spinner />
               </div>
             )}
             {(!searchResults ||

--- a/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-filter.component.tsx
+++ b/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-filter.component.tsx
@@ -188,15 +188,6 @@ export class SVVariantFilterComponent extends React.Component<Props, State> {
                 );
               }
             })}
-            <div style={styles.sortByContainer}>
-              {
-                <SVVariantSortItemComponent
-                  cleared={cleared}
-                  onSortChange={(e) => this.handleSortChange(e)}
-                  sortMetadata={sortMetadata}
-                />
-              }
-            </div>
           </div>
           <div style={styles.actionBtnContainer}>
             <button onClick={() => this.handleClear()} style={styles.clearBtn}>

--- a/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-row.component.tsx
+++ b/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-row.component.tsx
@@ -183,7 +183,9 @@ export class SVVariantRowComponent extends React.Component<Props, State> {
             <div style={styles.rowItem}>
             {variant.position ? `chr${variant.position.replace(/-chr/, ', chr')}` : "-"}
             </div>
-            <div style={styles.rowItem}>{variant.size}</div>
+            <div style={styles.rowItem}>
+              {variant.size && variant.size >= 0 ? variant.size : ""}
+            </div>
             <div style={styles.rowItem}>{variant.alleleCount}</div>
             <div style={styles.rowItem}>{variant.alleleNumber}</div>
             <div style={styles.rowItem}>{variant.alleleFrequency}</div>

--- a/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-search.component.tsx
@@ -237,13 +237,13 @@ export class SVVariantSearchComponent extends React.Component<Props, State> {
           svVariantListSize > 0 &&
           environment.genoFilters ? (
             <div onClick={() => this.showFilter()} style={styles.filterBtn}>
-              <ClrIcon shape="filter-2" /> Filter & Sort
+              <ClrIcon shape="filter-2" /> Filter
             </div>
           ) : scrollClean ? (
             <div> </div>
           ) : (
             <div onClick={() => this.showFilter()} style={styles.filterBtn}>
-              <ClrIcon shape="filter-2" /> Filter & Sort
+              <ClrIcon shape="filter-2" /> Filter
             </div>
           )}
           <React.Fragment>


### PR DESCRIPTION
Goal: move sort actions from filter menu to column headers while maintaining current sort functionality

Sort results table be the field user clicks on in column header

maintain ascending/descending click sequence used in filter panel and the up/down arrow display next to column name

remove dotted lines from under the column headers

remove “Sort by” from filter panel

change “Filter & Sort” button to “Filter”

add tooltip to all column headers - “Click to sort”

In the SV section, use the list below to rank order consequence values (from most severe to least severe) when variants are sorted.

Please notify if consequence values in our dataset are not present in the list below


PREDICTED_LOF

PREDICTED_COPY_GAIN

PREDICTED_INTRAGENIC_EXON_DUP

PREDICTED_PARTIAL_EXON_DUP

PREDICTED_TSS_DUP

PREDICTED_DUP_PARTIAL

PREDICTED_INV_SPAN

PREDICTED_MSV_EXON_OVERLAP

PREDICTED_UTR

PREDICTED_INTRONIC

PREDICTED_BREAKEND_EXONIC

PREDICTED_PROMOTER

PREDICTED_INTERGENIC

PREDICTED_NEAREST_TSS

PREDICTED_NONCODING_SPAN

PREDICTED_NONCODING_BREAKPOINT