### PR TITLE
[risk=no] small ui fixes

### DIFF
--- a/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
+++ b/public-ui/src/app/data-browser/views/genomic-view/components/variant-search.component.tsx
@@ -34,16 +34,19 @@ const styles = reactStyles({
   filterBtn: {
     fontFamily: "gothamBold",
     color: "#216FB4",
-    cursor: "Pointer",
+    cursor: "pointer",
     width: "fit-content",
+    zIndex: 100,
   },
   filterContainer: {
     position: "relative",
+    zIndex: 100,
   },
   resultInfo: {
     display: "grid",
     gridTemplateColumns: "11.5rem 1fr",
     alignItems: "baseline",
+    zIndex: 100,
   },
 });
 

--- a/public-ui/src/app/data-browser/views/quick-search/home-view-react.component.tsx
+++ b/public-ui/src/app/data-browser/views/quick-search/home-view-react.component.tsx
@@ -125,7 +125,7 @@ export const homeCss = `
 	font-size: 14px;
 	display: flex;
 	flex-direction: column;
-	padding-bottom:4rem;
+	padding-bottom:2rem;
 }
 .result-box-body-item {
 }
@@ -515,59 +515,57 @@ export const ResultLinksComponent = class extends React.Component<ResultLinkProp
             </span>
           )}
           {/* SNVs/Indels without search */}
-          {domainType === "snvs" && name === "SNVs/Indels" && !searchWord && (
-            <React.Fragment>
-              <span className="result-box-body-item">
-                <span className="result-stat">
-                  {wgsSRParticipantCount.toLocaleString()}
-                </span>
-                <div style={{ paddingTop: ".25rem" }}>
-                  {" "}
-                  Participants in Short-Read <br></br>
-                  Whole Genome Sequencing <br></br>
-                  (WGS) dataset
-                </div>
-
-                <React.Fragment>
-                  <span
-                    style={{ paddingTop: "1rem", fontSize: "28px" }}
-                    className="result-stat"
-                  >
+            {domainType === "snvs" && name === "SNVs/Indels" && !searchWord && (
+              <React.Fragment>
+                <span className="result-box-body-item">
+                  <span className="result-stat">
                     {variantListSize.toLocaleString()}
                   </span>
                   <span className="result-box-stat-label">
                     SNVs/Indels
                   </span>
-                </React.Fragment>
-              </span>
-            </React.Fragment>
-          )}
-          {/* Structural Variants without search */}
-          {domainType === "svs" && name === "Structural Variants" && !searchWord && (
-            <React.Fragment>
-              <span className="result-box-body-item">
-                <span className="result-stat">
-                  {wgsSVParticipantCount.toLocaleString()}
-                </span>
-                <div style={{ paddingTop: ".25rem" }}>
-                  Participants in the Short-Read WGS Structural Variants dataset
-                </div>
 
-                <React.Fragment>
-                  <span
-                    style={{ paddingTop: "1rem", fontSize: "28px" }}
-                    className="result-stat"
-                  >
+                  <React.Fragment>
+                    <span
+                      style={{ paddingTop: "2rem", fontSize: "28px" }}
+                      className="result-stat"
+                    >
+                      {wgsSRParticipantCount.toLocaleString()}
+                    </span>
+                    <div style={{ paddingTop: ".25rem" }}>
+                      Participants in the Short-Read
+                      Whole Genome Sequencing
+                      (WGS) dataset
+                    </div>
+                  </React.Fragment>
+                </span>
+              </React.Fragment>
+            )}
+          {/* Structural Variants without search */}
+            {domainType === "svs" && name === "Structural Variants" && !searchWord && (
+              <React.Fragment>
+                <span className="result-box-body-item">
+                  <span className="result-stat">
                     {svVariantListSize.toLocaleString()}
                   </span>
                   <span className="result-box-stat-label">
                     Structural Variants
                   </span>
-                </React.Fragment>
 
-              </span>
-            </React.Fragment>
-          )}
+                  <React.Fragment>
+                    <span
+                      style={{ paddingTop: "2rem", fontSize: "28px" }}
+                      className="result-stat"
+                    >
+                      {wgsSVParticipantCount.toLocaleString()}
+                    </span>
+                    <div style={{ paddingTop: ".25rem" }}>
+                      Participants in the Short-Read WGS Structural Variants dataset
+                    </div>
+                  </React.Fragment>
+                </span>
+              </React.Fragment>
+            )}
           {searchWord && domainType === "ehr" && (
             <span className="result-box-body-item">
               <span className="result-box-stat-label">
@@ -624,67 +622,66 @@ export const ResultLinksComponent = class extends React.Component<ResultLinkProp
             </span>
           )}
           {/* SNVs/Indels with search */}
-          {domainType === "snvs" &&
-            name === "SNVs/Indels" &&
-            searchWord &&
-            !loadingVariantListSize &&
-            variantListSize > 0 && (
-              <React.Fragment>
-                <span className="result-box-body-item">
-                  <span className="result-stat">
-                    {wgsSRParticipantCount.toLocaleString()}
-                  </span>
-                  <div style={{ paddingTop: ".25rem" }}>
-                    {" "}
-                    Participants in Short-Read <br></br>
-                    Whole Genome Sequencing <br></br>
-                    (WGS) dataset
-                  </div>
-
-                  <React.Fragment>
-                    <span
-                      style={{ paddingTop: "1rem", fontSize: "28px" }}
-                      className="result-stat"
-                    >
+            {domainType === "snvs" &&
+              name === "SNVs/Indels" &&
+              searchWord &&
+              !loadingVariantListSize &&
+              variantListSize > 0 && (
+                <React.Fragment>
+                  <span className="result-box-body-item">
+                    <span className="result-stat">
                       {variantListSize.toLocaleString()}
                     </span>
                     <span className="result-box-stat-label">
                       SNVs/Indels
                     </span>
-                  </React.Fragment>
-                </span>
-              </React.Fragment>
-            )}
-          {/* Structural Variants with search */}
-          {domainType === "svs" &&
-            name === "Structural Variants" &&
-            searchWord &&
-            !loadingSVVariantListSize &&
-            svVariantListSize > 0 && (
-              <React.Fragment>
-                <span className="result-box-body-item">
-                  <span className="result-stat">
-                    {wgsSVParticipantCount.toLocaleString()}
-                  </span>
-                  <div style={{ paddingTop: ".25rem" }}>
-                    Participants in Short-Read <br></br>
-                    WGS Structural Variants dataset
-                  </div>
 
-                  <React.Fragment>
-                    <span
-                      style={{ paddingTop: "1rem", fontSize: "28px" }}
-                      className="result-stat"
-                    >
+                    <React.Fragment>
+                      <span
+                        style={{ paddingTop: "2rem", fontSize: "28px" }}
+                        className="result-stat"
+                      >
+                        {wgsSRParticipantCount.toLocaleString()}
+                      </span>
+                      <div style={{ paddingTop: ".25rem" }}>
+                        Participants in Short-Read <br></br>
+                        Whole Genome Sequencing <br></br>
+                        (WGS) dataset
+                      </div>
+                    </React.Fragment>
+                  </span>
+                </React.Fragment>
+              )}
+          {/* Structural Variants with search */}
+            {domainType === "svs" &&
+              name === "Structural Variants" &&
+              searchWord &&
+              !loadingSVVariantListSize &&
+              svVariantListSize > 0 && (
+                <React.Fragment>
+                  <span className="result-box-body-item">
+                    <span className="result-stat">
                       {svVariantListSize.toLocaleString()}
                     </span>
                     <span className="result-box-stat-label">
                       Structural Variants
                     </span>
-                  </React.Fragment>
-                </span>
-              </React.Fragment>
-            )}
+
+                    <React.Fragment>
+                      <span
+                        style={{ paddingTop: "2rem", fontSize: "28px" }}
+                        className="result-stat"
+                      >
+                        {wgsSVParticipantCount.toLocaleString()}
+                      </span>
+                      <div style={{ paddingTop: ".25rem" }}>
+                        Participants in Short-Read <br></br>
+                        WGS Structural Variants dataset
+                      </div>
+                    </React.Fragment>
+                  </span>
+                </React.Fragment>
+              )}
           {name.toLowerCase() === "physical measurements" && (
             <span style={styles.resultBodyDescription}>
               Participants have the option to provide a standard set of physical

--- a/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-table.component.tsx
+++ b/public-ui/src/app/data-browser/views/sv-genomic-view/components/sv-variant-table.component.tsx
@@ -303,7 +303,7 @@ export class SVVariantTableComponent extends React.Component<Props, State> {
             <div className="header-layout">
               {this.renderColumnHeader("variantId", "Variant ID", styles.first)}
               {this.renderColumnHeader("variantType", "Variant Type")}
-              {this.renderColumnHeader("consequence", "Predicted Consequence(s)")}
+              {this.renderColumnHeader("consequence", "Pred Consequence(s)")}
               {this.renderColumnHeader("position", "Position")}
               {this.renderColumnHeader("size", "Size")}
               {this.renderColumnHeader("alleleCount", "Allele Count")}

--- a/public-ui/src/app/shared/components/rh-header/rh-header.tsx
+++ b/public-ui/src/app/shared/components/rh-header/rh-header.tsx
@@ -202,6 +202,15 @@ export class RhHeader extends React.Component<{}, State> {
                           <div className="item-expand" />
                         </li>
                         <li
+                          id="menu-item-3299"
+                          className="menu-item menu-item-type-post_type_archive menu-item-object-imputation menu-item-3299"
+                        >
+                          <a href="https://imputation.researchallofus.org/" target="_blank" rel="noopener noreferrer">
+                            Imputation Service
+                          </a>
+                          <div className="item-expand" />
+                        </li>
+                        <li
                           id="menu-item-1462"
                           className="menu-item menu-item-type-post_type menu-item-object-page menu-item-1462"
                         >
@@ -242,15 +251,6 @@ export class RhHeader extends React.Component<{}, State> {
                         >
                           <a href="https://www.researchallofus.org/publication-directory/">
                             Publication Directory
-                          </a>
-                          <div className="item-expand" />
-                        </li>
-                        <li
-                          id="menu-item-3299"
-                          className="menu-item menu-item-type-post_type_archive menu-item-object-imputation menu-item-3299"
-                        >
-                          <a href="https://imputation.researchallofus.org/" target="_blank" rel="noopener noreferrer">
-                            Imputation Service
                           </a>
                           <div className="item-expand" />
                         </li>

--- a/public-ui/src/environments/environment.stable.ts
+++ b/public-ui/src/environments/environment.stable.ts
@@ -14,7 +14,7 @@ export const environment = {
   genoFilters: true,
   fitbitCDRUpdate: true,
   infiniteSrcoll: true,
-  svVCFBrowser: false,
+  svVCFBrowser: true,
   heatmap: true,
   combinedAgeGenderChart: true,
   geneLeads: false,

--- a/public-ui/src/environments/environment.staging.ts
+++ b/public-ui/src/environments/environment.staging.ts
@@ -14,7 +14,7 @@ export const environment = {
   genoFilters: true,
   fitbitCDRUpdate: true,
   infiniteSrcoll: true,
-  svVCFBrowser: false,
+  svVCFBrowser: true,
   heatmap: true,
   combinedAgeGenderChart: true,
   geneLeads: false,


### PR DESCRIPTION
1. The Imputation Service menu item should be in the Data & Tools menu, between Survey Explorer and Researcher Workbench (it’s currently in the Discover menu - this was my mistake in the ticket)
2. In SV section, for the results table column header “Predicted Consequence(s)“, shorten “Predicted” to “Pred.” (keep the full word “Predicted” in the variant card)
3. In SNV/Indel section, the filter icon is still clickable, but not the word Filter. Not sure if the gene leads graphic has something to do with this on test
4. Add “the” before “Short-Read” in the SNV/Indel homepage card
for SNV/Indel and SV cards on the homepage:
5. Swap the counts and labels so the variant count is the 35px top number and the participant count is the 28px bottom number
increase padding above bottom number from 1rem to 2rem
for the last one, this is how it looks when I changed it in inspector
6. For the EHR homepage cards, change the result box body div bottom padding from 4rem to 2rem to match the survey cards